### PR TITLE
Corrected dead link to Postgresql storage target page

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -20,7 +20,7 @@
 **** xref:storage:storage-targets/sql-databases/mariadb.adoc[MariaDB]
 **** xref:storage:storage-targets/sql-databases/mysql.adoc[MySQL]
 **** xref:storage:storage-targets/sql-databases/oracle.adoc[Oracle]
-**** xref:storage:storage-targets/sql-databases/postresql.adoc[Postgres]
+**** xref:storage:storage-targets/sql-databases/postgresql.adoc[Postgres]
 **** xref:storage:storage-targets/sql-databases/sqlite.adoc[Sqlite]
 *** Blob Stores
 **** AWS


### PR DESCRIPTION
While browsing the documentation i noticed a dead link in the navigation bar. I believe this should fix it.