### PR TITLE
Add check for empty PriorityQueue on load (#233)

### DIFF
--- a/persistence/binary/src/main/java/one/microstream/persistence/binary/java/util/BinaryHandlerPriorityQueue.java
+++ b/persistence/binary/src/main/java/one/microstream/persistence/binary/java/util/BinaryHandlerPriorityQueue.java
@@ -128,7 +128,10 @@ extends AbstractBinaryHandlerCustomIterable<PriorityQueue<?>>
 	)
 	{
 		return new PriorityQueue<>(
-			X.checkArrayRange(getElementCount(data)),
+			Math.max(
+				1, // initialCapacity cannot be smaller than 1
+				X.checkArrayRange(getElementCount(data))
+			),
 			getComparator(data, handler)
 		);
 	}


### PR DESCRIPTION
The initial capacity of the java.util.PriorityQueue cannot be smaller than 1. 
So when an empty queue was stored, we have to add a check in the type handler when loading.