### PR TITLE
Volatile to atomic

### DIFF
--- a/base/src/main/java/one/microstream/concurrency/Threaded.java
+++ b/base/src/main/java/one/microstream/concurrency/Threaded.java
@@ -24,6 +24,7 @@ import static java.lang.System.identityHashCode;
 import static java.lang.Thread.currentThread;
 
 import java.lang.ref.WeakReference;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -151,7 +152,7 @@ public class Threaded<E> implements ConsolidatableCollection, OptimizableCollect
 	////////////////////
 
 	private volatile Entry<E>[] slots;
-	private volatile int size;
+	private AtomicInteger size = new AtomicInteger();
 	private volatile Consumer<E> cleanUpOperation;
 
 
@@ -170,7 +171,7 @@ public class Threaded<E> implements ConsolidatableCollection, OptimizableCollect
 	{
 		super();
 		this.slots = new Entry[1]; // in this case small memory need is preferable to good low-grow performance
-		this.size = 0;
+		this.size.set(0);
 		this.cleanUpOperation = null;
 	}
 
@@ -194,7 +195,7 @@ public class Threaded<E> implements ConsolidatableCollection, OptimizableCollect
 	{
 		super();
 		this.slots = Threaded.<E>createSlots(initialCapacity);
-		this.size = 0;
+		this.size.set(0);
 		this.cleanUpOperation = null;
 	}
 
@@ -362,7 +363,7 @@ public class Threaded<E> implements ConsolidatableCollection, OptimizableCollect
 		(slots = this.slots)[threadIdHashCode & slots.length - 1] = entry.next(slots[threadIdHashCode & slots.length - 1]);
 
 		// increase size and rebuild slots array if necessary
-		if(this.size++ == slots.length)
+		if(this.size.getAndIncrement() == slots.length)
 		{
 			this.internalOptimize();
 		}
@@ -405,7 +406,7 @@ public class Threaded<E> implements ConsolidatableCollection, OptimizableCollect
 	@SuppressWarnings("unchecked")
 	private int internalOptimize()
 	{
-		final Entry<E>[] slots, buffer = new Entry[this.size];
+		final Entry<E>[] slots, buffer = new Entry[this.size.get()];
 		final int slotsLength = (slots = this.slots).length;
 		final Consumer<E> cleanUpOp = this.cleanUpOperation;
 		int count = 0;
@@ -464,7 +465,7 @@ public class Threaded<E> implements ConsolidatableCollection, OptimizableCollect
 			newSlots[index = identityHashCode(thread) & modulo] = new Entry<>(thread, buffer[i].value, newSlots[index]);
 		}
 
-		this.size = count;
+		this.size.set(count);
 		this.slots = newSlots;
 		return newSlots.length - count;
 
@@ -533,9 +534,9 @@ public class Threaded<E> implements ConsolidatableCollection, OptimizableCollect
 	@Override
 	public synchronized long consolidate()
 	{
-		final int oldSize = this.size;
+		final int oldSize = this.size.get();
 		this.internalOptimize();
-		return oldSize - this.size;
+		return oldSize - this.size.get();
 	}
 
 	/**
@@ -553,7 +554,7 @@ public class Threaded<E> implements ConsolidatableCollection, OptimizableCollect
 	@Override
 	public boolean isEmpty()
 	{
-		return this.size == 0;
+		return this.size.get() == 0;
 	}
 
 	/**
@@ -570,7 +571,7 @@ public class Threaded<E> implements ConsolidatableCollection, OptimizableCollect
 	@Override
 	public long size()
 	{
-		return this.size;
+		return this.size.get();
 	}
 
 	public synchronized boolean containsSearched(final Predicate<? super E> predicate)

--- a/cache/cache/src/main/java/one/microstream/cache/types/Cache.java
+++ b/cache/cache/src/main/java/one/microstream/cache/types/Cache.java
@@ -38,6 +38,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 import javax.cache.CacheException;
@@ -183,8 +184,8 @@ public interface Cache<K, V> extends javax.cache.Cache<K, V>, Unwrappable
 		private final ExecutorService                             executorService         ;
 		private final CacheConfigurationMXBean                    cacheConfigurationMXBean;
 		private final CacheStatisticsMXBean                       cacheStatisticsMXBean   ;
-		private volatile boolean                                  isStatisticsEnabled     ;
-		private volatile boolean                                  isClosed                ;
+		private AtomicBoolean                                     isStatisticsEnabled     = new AtomicBoolean();
+		private AtomicBoolean                                     isClosed                = new AtomicBoolean();
 
 		/*
 		 * According to spec cache and configuration, which may be mutable,
@@ -352,18 +353,18 @@ public interface Cache<K, V> extends javax.cache.Cache<K, V>, Unwrappable
 		@Override
 		public boolean isClosed()
 		{
-			return this.isClosed;
+			return this.isClosed.get();
 		}
 
 		@Override
 		public synchronized void close()
 		{
-			if(this.isClosed)
+			if(this.isClosed.get())
 			{
 				return;
 			}
 
-			this.isClosed = true;
+			this.isClosed.set(true);
 
 			this.manager.removeCache(this.name);
 
@@ -555,8 +556,8 @@ public interface Cache<K, V> extends javax.cache.Cache<K, V>, Unwrappable
 			this.keyValidator.validate(key);
 			this.valueValidator.validate(value);
 
-			final boolean                    isStatisticsEnabled = this.isStatisticsEnabled;
-			final long                       start               = isStatisticsEnabled
+			final AtomicBoolean              isStatisticsEnabled = this.isStatisticsEnabled;
+			final long                       start               = isStatisticsEnabled.get()
 				? System.nanoTime()
 				: 0;
 
@@ -641,7 +642,7 @@ public interface Cache<K, V> extends javax.cache.Cache<K, V>, Unwrappable
 			{
 				eventDispatcher.dispatch(this.listenerRegistrations);
 			}
-			if(isStatisticsEnabled && putCount > 0)
+			if(isStatisticsEnabled.get() && putCount > 0)
 			{
 				final CacheStatisticsMXBean cacheStatisticsMXBean = this.cacheStatisticsMXBean;
 				cacheStatisticsMXBean.increaseCachePuts(putCount);
@@ -657,8 +658,8 @@ public interface Cache<K, V> extends javax.cache.Cache<K, V>, Unwrappable
 			this.keyValidator.validate(key);
 			this.valueValidator.validate(value);
 
-			final boolean                    isStatisticsEnabled = this.isStatisticsEnabled;
-			final long                       start               = isStatisticsEnabled
+			final AtomicBoolean              isStatisticsEnabled = this.isStatisticsEnabled;
+			final long                       start               = isStatisticsEnabled.get()
 				? System.nanoTime()
 				: 0;
 
@@ -744,7 +745,7 @@ public interface Cache<K, V> extends javax.cache.Cache<K, V>, Unwrappable
 			{
 				eventDispatcher.dispatch(this.listenerRegistrations);
 			}
-			if(isStatisticsEnabled)
+			if(isStatisticsEnabled.get())
 			{
 				final CacheStatisticsMXBean cacheStatisticsMXBean = this.cacheStatisticsMXBean;
 				if(result == null)
@@ -780,7 +781,7 @@ public interface Cache<K, V> extends javax.cache.Cache<K, V>, Unwrappable
 			map.keySet().forEach(this.keyValidator::validate);
 			map.values().forEach(this.valueValidator::validate);
 
-			final boolean                    isStatisticsEnabled = this.isStatisticsEnabled;
+			final boolean                    isStatisticsEnabled = this.isStatisticsEnabled.get();
 			final long                       start               = isStatisticsEnabled
 				? System.nanoTime()
 				: 0;
@@ -938,7 +939,7 @@ public interface Cache<K, V> extends javax.cache.Cache<K, V>, Unwrappable
 			this.keyValidator.validate(key);
 			this.valueValidator.validate(value);
 
-			final boolean                    isStatisticsEnabled = this.isStatisticsEnabled;
+			final boolean                    isStatisticsEnabled = this.isStatisticsEnabled.get();
 			final long                       start               = isStatisticsEnabled
 				? System.nanoTime()
 				: 0;
@@ -1036,7 +1037,7 @@ public interface Cache<K, V> extends javax.cache.Cache<K, V>, Unwrappable
 
 			this.keyValidator.validate(key);
 
-			final boolean                    isStatisticsEnabled = this.isStatisticsEnabled;
+			final boolean                    isStatisticsEnabled = this.isStatisticsEnabled.get();
 			final long                       start               = isStatisticsEnabled
 				? System.nanoTime()
 				: 0;
@@ -1101,7 +1102,7 @@ public interface Cache<K, V> extends javax.cache.Cache<K, V>, Unwrappable
 			this.keyValidator.validate(key);
 			this.valueValidator.validate(oldValue);
 
-			final boolean                    isStatisticsEnabled = this.isStatisticsEnabled;
+			final boolean                    isStatisticsEnabled = this.isStatisticsEnabled.get();
 			final long                       start               = isStatisticsEnabled
 				? System.nanoTime()
 				: 0;
@@ -1187,7 +1188,7 @@ public interface Cache<K, V> extends javax.cache.Cache<K, V>, Unwrappable
 
 			this.keyValidator.validate(key);
 
-			final boolean                    isStatisticsEnabled = this.isStatisticsEnabled;
+			final boolean                    isStatisticsEnabled = this.isStatisticsEnabled.get();
 			final long                       start               = isStatisticsEnabled
 				? System.nanoTime()
 				: 0;
@@ -1256,7 +1257,7 @@ public interface Cache<K, V> extends javax.cache.Cache<K, V>, Unwrappable
 			this.valueValidator.validate(newValue);
 			this.valueValidator.validate(oldValue);
 
-			final boolean                    isStatisticsEnabled = this.isStatisticsEnabled;
+			final boolean                    isStatisticsEnabled = this.isStatisticsEnabled.get();
 			final long                       start               = isStatisticsEnabled
 				? System.nanoTime()
 				: 0;
@@ -1348,7 +1349,7 @@ public interface Cache<K, V> extends javax.cache.Cache<K, V>, Unwrappable
 			this.keyValidator.validate(key);
 			this.valueValidator.validate(value);
 
-			final boolean                    isStatisticsEnabled = this.isStatisticsEnabled;
+			final boolean                    isStatisticsEnabled = this.isStatisticsEnabled.get();
 			final long                       start               = isStatisticsEnabled
 				? System.nanoTime()
 				: 0;
@@ -1423,7 +1424,7 @@ public interface Cache<K, V> extends javax.cache.Cache<K, V>, Unwrappable
 			this.keyValidator.validate(key);
 			this.valueValidator.validate(value);
 
-			final boolean                    isStatisticsEnabled = this.isStatisticsEnabled;
+			final boolean                    isStatisticsEnabled = this.isStatisticsEnabled.get();
 			final long                       start               = isStatisticsEnabled
 				? System.nanoTime()
 				: 0;
@@ -1499,7 +1500,7 @@ public interface Cache<K, V> extends javax.cache.Cache<K, V>, Unwrappable
 
 			keys.forEach(this.keyValidator::validate);
 
-			final boolean                    isStatisticsEnabled = this.isStatisticsEnabled;
+			final boolean                    isStatisticsEnabled = this.isStatisticsEnabled.get();
 			final long                       now                 = System.currentTimeMillis();
 			final CacheEventDispatcher<K, V> eventDispatcher     = this.listenerRegistrations.size() > 0L
 				? CacheEventDispatcher.New()
@@ -1615,7 +1616,7 @@ public interface Cache<K, V> extends javax.cache.Cache<K, V>, Unwrappable
 		{
 			this.ensureOpen();
 
-			final boolean                    isStatisticsEnabled = this.isStatisticsEnabled;
+			final boolean                    isStatisticsEnabled = this.isStatisticsEnabled.get();
 			int                              removed             = 0;
 			final long                       now                 = System.currentTimeMillis();
 			final CacheEventDispatcher<K, V> eventDispatcher     = this.listenerRegistrations.size() > 0L
@@ -1734,7 +1735,7 @@ public interface Cache<K, V> extends javax.cache.Cache<K, V>, Unwrappable
 		@Override
 		public void setStatisticsEnabled(final boolean enabled)
 		{
-			this.isStatisticsEnabled = enabled;
+			this.isStatisticsEnabled.set(enabled);
 
 			this.updateConfiguration(c -> c.setStatisticsEnabled(enabled));
 
@@ -1822,7 +1823,7 @@ public interface Cache<K, V> extends javax.cache.Cache<K, V>, Unwrappable
 
 			this.keyValidator.validate(key);
 
-			final boolean isStatisticsEnabled = this.isStatisticsEnabled;
+			final boolean isStatisticsEnabled = this.isStatisticsEnabled.get();
 			long          start               = isStatisticsEnabled
 				? System.nanoTime()
 				: 0;
@@ -2096,7 +2097,7 @@ public interface Cache<K, V> extends javax.cache.Cache<K, V>, Unwrappable
 
 		private void ensureOpen()
 		{
-			if(this.isClosed)
+			if(this.isClosed.get())
 			{
 				throw new IllegalStateException("Cache is closed");
 			}
@@ -2108,7 +2109,7 @@ public interface Cache<K, V> extends javax.cache.Cache<K, V>, Unwrappable
 			final Reference<CachedValue>     cachedValueReference
 		)
 		{
-			final boolean isStatisticsEnabled = this.isStatisticsEnabled;
+			final boolean isStatisticsEnabled = this.isStatisticsEnabled.get();
 			final long    start               = isStatisticsEnabled
 				? System.nanoTime()
 				: 0;
@@ -2241,7 +2242,7 @@ public interface Cache<K, V> extends javax.cache.Cache<K, V>, Unwrappable
 				}
 			}
 
-			if(this.isStatisticsEnabled && evictionCount > 0)
+			if(this.isStatisticsEnabled.get() && evictionCount > 0)
 			{
 				if(eventDispatcher != null)
 				{
@@ -2441,7 +2442,7 @@ public interface Cache<K, V> extends javax.cache.Cache<K, V>, Unwrappable
 				this.nextEntry           = null;
 				this.lastEntry           = null;
 				this.now                 = System.currentTimeMillis();
-				this.isStatisticsEnabled = Cache.Default.this.isStatisticsEnabled;
+				this.isStatisticsEnabled = Cache.Default.this.isStatisticsEnabled.get();
 			}
 
 			private void fetch()

--- a/storage/storage/src/main/java/one/microstream/storage/types/StorageChannelTask.java
+++ b/storage/storage/src/main/java/one/microstream/storage/types/StorageChannelTask.java
@@ -22,6 +22,8 @@ package one.microstream.storage.types;
 
 import one.microstream.storage.exceptions.StorageException;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 public interface StorageChannelTask extends StorageTask
 {
 	public void incrementCompletionProgress();
@@ -43,7 +45,7 @@ public interface StorageChannelTask extends StorageTask
 		private          int         remainingForCompletion;
 		private          int         remainingForProcessing;
 
-		private volatile boolean     hasProblems;
+		private AtomicBoolean        hasProblems = new AtomicBoolean();
 		private final    Throwable[] problems   ; // unshared instance conveniently abused as a second lock
 
 
@@ -70,7 +72,7 @@ public interface StorageChannelTask extends StorageTask
 
 		private void checkForProblems()
 		{
-			if(!this.hasProblems)
+			if(!this.hasProblems.get())
 			{
 				return;
 			}
@@ -149,7 +151,7 @@ public interface StorageChannelTask extends StorageTask
 		@Override
 		public final boolean hasProblems()
 		{
-			return this.hasProblems;
+			return this.hasProblems.get();
 		}
 
 		@Override
@@ -170,7 +172,7 @@ public interface StorageChannelTask extends StorageTask
 			if(this.problems[hashIndex] == null)
 			{
 				this.problems[hashIndex] = problem;
-				this.hasProblems = true;
+				this.hasProblems.set(true);
 			}
 			else
 			{

--- a/storage/storage/src/main/java/one/microstream/storage/types/StorageRequestTaskExportEntitiesByType.java
+++ b/storage/storage/src/main/java/one/microstream/storage/types/StorageRequestTaskExportEntitiesByType.java
@@ -22,6 +22,7 @@ package one.microstream.storage.types;
 
 import static one.microstream.X.notNull;
 
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -238,7 +239,7 @@ public interface StorageRequestTaskExportEntitiesByType extends StorageRequestTa
 		final StorageEntityTypeHandler         type            ;
 		final Predicate<? super StorageEntity> predicateEntity ;
 
-		private volatile int currentChannel;
+		private final AtomicInteger currentChannel = new AtomicInteger();
 
 
 
@@ -268,13 +269,13 @@ public interface StorageRequestTaskExportEntitiesByType extends StorageRequestTa
 
 		final synchronized void incrementProgress()
 		{
-			this.currentChannel++;
+			this.currentChannel.incrementAndGet();
 			this.notifyAll();
 		}
 
 		final boolean isCurrentChannel(final StorageChannel channel)
 		{
-			return this.currentChannel == channel.channelIndex();
+			return this.currentChannel.get() == channel.channelIndex();
 		}
 
 		final boolean isLastChannel(final StorageChannel channel)

--- a/storage/storage/src/main/java/one/microstream/storage/types/StorageRequestTaskImportData.java
+++ b/storage/storage/src/main/java/one/microstream/storage/types/StorageRequestTaskImportData.java
@@ -20,6 +20,7 @@ package one.microstream.storage.types;
  * #L%
  */
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 import one.microstream.X;
@@ -65,8 +66,8 @@ public interface StorageRequestTaskImportData extends StorageRequestTask
 		// starting point for the channels to process
 		private final SourceFileSlice[] sourceFileTails;
 
-		private volatile boolean complete   ;
-		private volatile long    maxObjectId;
+		private AtomicBoolean    complete  = new AtomicBoolean();
+		private volatile long    maxObjectId; //TODO Check, why it is not assigned?
 		private          Thread  readThread ;
 
 
@@ -153,7 +154,7 @@ public interface StorageRequestTaskImportData extends StorageRequestTask
 				}
 			}
 //			DEBUGStorage.println("* completed reading source files");
-			this.complete = true;
+			this.complete.set(true);
 		}
 
 		
@@ -363,7 +364,7 @@ public interface StorageRequestTaskImportData extends StorageRequestTask
 						// wait for the next batch to import (successor of the current batch)
 						while(currentSourceFile.next == null)
 						{
-							if(this.complete)
+							if(this.complete.get())
 							{
 //								DEBUGStorage.println(channel.channelIndex() + " done importing.");
 								// there will be no more next source file, so abort (task is complete)


### PR DESCRIPTION
Change all primitivy types with volatile to Atomic types. This should guarantee atomic operations on these variables, reduce the need for synchronized blocks and, most importantly, reduce the possibility of creating errors in the future with respect to synchronization.

It has been tested. By the test shows this solution a slightly better performance. 