### PR TITLE
Add type handler for CopyOnWriteArraySet

### DIFF
--- a/persistence/binary/src/main/java/one/microstream/persistence/binary/java/util/BinaryHandlerCopyOnWriteArraySet.java
+++ b/persistence/binary/src/main/java/one/microstream/persistence/binary/java/util/BinaryHandlerCopyOnWriteArraySet.java
@@ -1,0 +1,69 @@
+package one.microstream.persistence.binary.java.util;
+
+/*-
+ * #%L
+ * microstream-persistence-binary
+ * %%
+ * Copyright (C) 2019 - 2021 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is
+ * available at https://www.gnu.org/software/classpath/license.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * #L%
+ */
+
+import java.util.concurrent.CopyOnWriteArraySet;
+
+import one.microstream.persistence.binary.types.Binary;
+import one.microstream.persistence.types.PersistenceLoadHandler;
+
+
+public final class BinaryHandlerCopyOnWriteArraySet extends AbstractBinaryHandlerSet<CopyOnWriteArraySet<?>>
+{
+	///////////////////////////////////////////////////////////////////////////
+	// static methods //
+	///////////////////
+
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	private static Class<CopyOnWriteArraySet<?>> handledType()
+	{
+		return (Class)CopyOnWriteArraySet.class; // no idea how to get ".class" to work otherwise
+	}
+	
+	public static BinaryHandlerCopyOnWriteArraySet New()
+	{
+		return new BinaryHandlerCopyOnWriteArraySet();
+	}
+	
+	
+
+	///////////////////////////////////////////////////////////////////////////
+	// constructors //
+	/////////////////
+
+	BinaryHandlerCopyOnWriteArraySet()
+	{
+		super(handledType());
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// methods //
+	////////////
+
+	@Override
+	public final CopyOnWriteArraySet<?> create(final Binary data, final PersistenceLoadHandler handler)
+	{
+		return new CopyOnWriteArraySet<>();
+	}
+
+}

--- a/persistence/binary/src/main/java/one/microstream/persistence/binary/types/BinaryPersistence.java
+++ b/persistence/binary/src/main/java/one/microstream/persistence/binary/types/BinaryPersistence.java
@@ -75,6 +75,7 @@ import one.microstream.persistence.binary.java.time.BinaryHandlerZoneOffset;
 import one.microstream.persistence.binary.java.util.BinaryHandlerArrayDeque;
 import one.microstream.persistence.binary.java.util.BinaryHandlerArrayList;
 import one.microstream.persistence.binary.java.util.BinaryHandlerCopyOnWriteArrayList;
+import one.microstream.persistence.binary.java.util.BinaryHandlerCopyOnWriteArraySet;
 import one.microstream.persistence.binary.java.util.BinaryHandlerCurrency;
 import one.microstream.persistence.binary.java.util.BinaryHandlerDate;
 import one.microstream.persistence.binary.java.util.BinaryHandlerHashMap;
@@ -326,6 +327,7 @@ public final class BinaryPersistence extends Persistence
 			BinaryHandlerConcurrentHashMap.New()    ,
 			BinaryHandlerConcurrentLinkedQueue.New(),
 			BinaryHandlerCopyOnWriteArrayList.New() ,
+			BinaryHandlerCopyOnWriteArraySet.New()  ,
 
 			// remaining JDK collections (wrappers and the like) are handled dynamically
 


### PR DESCRIPTION
Adds a new type handler for CopyOnWriteArraySet for a proper persistence for this type. 
See #251 