### PR TITLE
change output in toString method to write more details when StorageBa…

### DIFF
--- a/storage/storage/src/main/java/one/microstream/storage/types/StorageConfiguration.java
+++ b/storage/storage/src/main/java/one/microstream/storage/types/StorageConfiguration.java
@@ -20,11 +20,11 @@ package one.microstream.storage.types;
  * #L%
  */
 
-import one.microstream.chars.VarString;
-import one.microstream.typing.Immutable;
-
 import static one.microstream.X.mayNull;
 import static one.microstream.X.notNull;
+
+import one.microstream.chars.VarString;
+import one.microstream.typing.Immutable;
 
 public interface StorageConfiguration
 {

--- a/storage/storage/src/main/java/one/microstream/storage/types/StorageConfiguration.java
+++ b/storage/storage/src/main/java/one/microstream/storage/types/StorageConfiguration.java
@@ -194,7 +194,7 @@ public interface StorageConfiguration
 				.add(this.housekeepingController).lf()
 				.add(this.entityCacheEvaluator  ).lf()
 				.add(this.dataFileEvaluator     ).lf()
-				.add(this.backupSetup == null ? "one.microstream.storage.types.StorageBackupSetup: null " : this.backupSetup).lf()
+				.add(this.backupSetup == null ? StorageBackupSetup.class.getName() + ": null": this.backupSetup).lf()
 				.toString()
 			;
 		}

--- a/storage/storage/src/main/java/one/microstream/storage/types/StorageConfiguration.java
+++ b/storage/storage/src/main/java/one/microstream/storage/types/StorageConfiguration.java
@@ -20,11 +20,11 @@ package one.microstream.storage.types;
  * #L%
  */
 
-import static one.microstream.X.mayNull;
-import static one.microstream.X.notNull;
-
 import one.microstream.chars.VarString;
 import one.microstream.typing.Immutable;
+
+import static one.microstream.X.mayNull;
+import static one.microstream.X.notNull;
 
 public interface StorageConfiguration
 {
@@ -194,7 +194,7 @@ public interface StorageConfiguration
 				.add(this.housekeepingController).lf()
 				.add(this.entityCacheEvaluator  ).lf()
 				.add(this.dataFileEvaluator     ).lf()
-				.add(this.backupSetup           ).lf()
+				.add(this.backupSetup == null ? "one.microstream.storage.types.StorageBackupSetup: null " : this.backupSetup).lf()
 				.toString()
 			;
 		}


### PR DESCRIPTION
Fix for the issue: https://github.com/microstream-one/microstream/issues/205
So now instead of:

```
...
one.microstream.storage.types.StorageDataFileEvaluator$Default:
 fileMinimumSize	= 1048576
 fileMaximumSize	= 8388608
 minimumUseRatio	= 0.75
 cleanupHeadFile	= true
null
```

is:

```
...
one.microstream.storage.types.StorageDataFileEvaluator$Default:
 fileMinimumSize	= 1048576
 fileMaximumSize	= 8388608
 minimumUseRatio	= 0.75
 cleanupHeadFile	= true
one.microstream.storage.types.StorageBackupSetup: null 
```

