### PR TITLE
Use the StorageManager instead of the EmbeddedStorageManager

### DIFF
--- a/cache/cache/src/main/java/one/microstream/cache/types/CacheStore.java
+++ b/cache/cache/src/main/java/one/microstream/cache/types/CacheStore.java
@@ -39,7 +39,7 @@ import javax.cache.integration.CacheWriterException;
 import one.microstream.collections.EqHashTable;
 import one.microstream.collections.types.XTable;
 import one.microstream.reference.Lazy;
-import one.microstream.storage.embedded.types.EmbeddedStorageManager;
+import one.microstream.storage.types.StorageManager;
 
 
 public interface CacheStore<K, V> extends CacheLoader<K, V>, CacheWriter<K, V>
@@ -47,7 +47,7 @@ public interface CacheStore<K, V> extends CacheLoader<K, V>, CacheWriter<K, V>
 	public Iterator<K> keys();
 	
 	
-	public static <K, V> CacheStore<K, V> New(final String cacheKey, final EmbeddedStorageManager storage)
+	public static <K, V> CacheStore<K, V> New(final String cacheKey, final StorageManager storage)
 	{
 		return new Default<>(cacheKey, storage);
 	}
@@ -55,9 +55,9 @@ public interface CacheStore<K, V> extends CacheLoader<K, V>, CacheWriter<K, V>
 	public static class Default<K, V> implements CacheStore<K, V>
 	{
 		private final String                 cacheKey;
-		private final EmbeddedStorageManager storage;
+		private final StorageManager storage;
 		
-		Default(final String cacheKey, final EmbeddedStorageManager storage)
+		Default(final String cacheKey, final StorageManager storage)
 		{
 			super();
 			


### PR DESCRIPTION
Hey, instead of using the implementation could you use the interface.

I've checked I did not see any impact, besides helping me in the cache integration with CDI where we prefer the interface instead of implementation.