### PR TITLE
Android type handler

### DIFF
--- a/persistence/binary-android/pom.xml
+++ b/persistence/binary-android/pom.xml
@@ -14,7 +14,7 @@
 	<artifactId>microstream-persistence-binary-android</artifactId>
 	
 	<name>MicroStream Persistence Android</name>
-	<description>MicroStream Persistence Specialized Type Handlers</description>
+	<description>MicroStream Persistence Specialized Android Type Handlers</description>
 	
 	<dependencies>
 		<dependency>

--- a/persistence/binary-android/pom.xml
+++ b/persistence/binary-android/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>one.microstream</groupId>
+		<artifactId>microstream-persistence-parent</artifactId>
+		<version>07.00.00-MS-GA-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+
+	<artifactId>microstream-persistence-binary-android</artifactId>
+	
+	<name>MicroStream Persistence Android</name>
+	<description>MicroStream Persistence Specialized Type Handlers</description>
+	
+	<dependencies>
+		<dependency>
+			<groupId>one.microstream</groupId>
+			<artifactId>microstream-persistence-binary</artifactId>
+			<version>07.00.00-MS-GA-SNAPSHOT</version>
+		</dependency>
+	</dependencies>
+	
+</project>

--- a/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerDuration.java
+++ b/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerDuration.java
@@ -1,0 +1,89 @@
+package one.microstream.persistence.binary.android.java.time;
+
+/*-
+ * #%L
+ * microstream-persistence-binary-android
+ * %%
+ * Copyright (C) 2019 - 2022 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is
+ * available at https://www.gnu.org/software/classpath/license.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * #L%
+ */
+
+import java.time.Duration;
+
+import one.microstream.persistence.binary.internal.AbstractBinaryHandlerCustomNonReferentialFixedLength;
+import one.microstream.persistence.binary.types.Binary;
+import one.microstream.persistence.types.PersistenceLoadHandler;
+import one.microstream.persistence.types.PersistenceStoreHandler;
+
+public final class BinaryHandlerDuration extends AbstractBinaryHandlerCustomNonReferentialFixedLength<Duration>
+{
+	///////////////////////////////////////////////////////////////////////////
+	// static methods //
+	///////////////////
+	
+	public static BinaryHandlerDuration New()
+	{
+		return new BinaryHandlerDuration();
+	}
+
+	
+	
+	///////////////////////////////////////////////////////////////////////////
+	// constructors //
+	/////////////////
+
+	BinaryHandlerDuration()
+	{
+		super(
+			Duration.class,
+			CustomFields(
+				CustomField(long.class, "nanos")
+			)
+		);
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// methods //
+	////////////
+	
+
+	@Override
+	public final void store(
+		final Binary                          data    ,
+		final Duration                        instance,
+		final long                            objectId,
+		final PersistenceStoreHandler<Binary> handler
+	)
+	{
+		data.storeEntityHeader(Long.BYTES, this.typeId(), objectId);
+		
+		data.store_long(instance.toNanos());
+	}
+
+	@Override
+	public final Duration create(final Binary data, final PersistenceLoadHandler handler)
+	{
+		return Duration.ofNanos(data.read_long(0L));
+	}
+
+	@Override
+	public final void updateState(final Binary data, final Duration instance, final PersistenceLoadHandler handler)
+	{
+		// no-op
+	}
+
+}

--- a/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerInstant.java
+++ b/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerInstant.java
@@ -29,6 +29,10 @@ import one.microstream.persistence.types.PersistenceStoreHandler;
 
 public final class BinaryHandlerInstant extends AbstractBinaryHandlerCustomNonReferentialFixedLength<Instant>
 {
+	static final long BINARY_OFFSET_SECOND =                                    0L;
+	static final long BINARY_OFFSET_NANO   = BINARY_OFFSET_SECOND  + Long   .BYTES;
+	static final long BINARY_LENGTH        = BINARY_OFFSET_NANO    + Integer.BYTES;
+	
 	///////////////////////////////////////////////////////////////////////////
 	// static methods //
 	///////////////////
@@ -49,7 +53,8 @@ public final class BinaryHandlerInstant extends AbstractBinaryHandlerCustomNonRe
 		super(
 			Instant.class,
 			CustomFields(
-				CustomField(long.class, "epochMilli")
+				CustomField(long.class, "second"),
+				CustomField(int.class , "nano"  )
 			)
 		);
 	}
@@ -69,15 +74,19 @@ public final class BinaryHandlerInstant extends AbstractBinaryHandlerCustomNonRe
 		final PersistenceStoreHandler<Binary> handler
 	)
 	{
-		data.storeEntityHeader(Long.BYTES, this.typeId(), objectId);
+		data.storeEntityHeader(BINARY_LENGTH, this.typeId(), objectId);
 		
-		data.store_long(instance.toEpochMilli());
+		data.store_long(BINARY_OFFSET_SECOND, instance.getEpochSecond());
+		data.store_int (BINARY_OFFSET_NANO  , instance.getNano()       );
 	}
 
 	@Override
 	public final Instant create(final Binary data, final PersistenceLoadHandler handler)
 	{
-		return Instant.ofEpochMilli(data.read_long(0L));
+		return Instant.ofEpochSecond(
+			data.read_long(BINARY_OFFSET_SECOND),
+			data.read_int (BINARY_OFFSET_NANO)
+		);
 	}
 
 	@Override

--- a/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerInstant.java
+++ b/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerInstant.java
@@ -1,0 +1,89 @@
+package one.microstream.persistence.binary.android.java.time;
+
+/*-
+ * #%L
+ * microstream-persistence-binary-android
+ * %%
+ * Copyright (C) 2019 - 2022 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is
+ * available at https://www.gnu.org/software/classpath/license.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * #L%
+ */
+
+import java.time.Instant;
+
+import one.microstream.persistence.binary.internal.AbstractBinaryHandlerCustomNonReferentialFixedLength;
+import one.microstream.persistence.binary.types.Binary;
+import one.microstream.persistence.types.PersistenceLoadHandler;
+import one.microstream.persistence.types.PersistenceStoreHandler;
+
+public final class BinaryHandlerInstant extends AbstractBinaryHandlerCustomNonReferentialFixedLength<Instant>
+{
+	///////////////////////////////////////////////////////////////////////////
+	// static methods //
+	///////////////////
+	
+	public static BinaryHandlerInstant New()
+	{
+		return new BinaryHandlerInstant();
+	}
+
+	
+	
+	///////////////////////////////////////////////////////////////////////////
+	// constructors //
+	/////////////////
+
+	BinaryHandlerInstant()
+	{
+		super(
+			Instant.class,
+			CustomFields(
+				CustomField(long.class, "epochMilli")
+			)
+		);
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// methods //
+	////////////
+	
+
+	@Override
+	public final void store(
+		final Binary                          data    ,
+		final Instant                         instance,
+		final long                            objectId,
+		final PersistenceStoreHandler<Binary> handler
+	)
+	{
+		data.storeEntityHeader(Long.BYTES, this.typeId(), objectId);
+		
+		data.store_long(instance.toEpochMilli());
+	}
+
+	@Override
+	public final Instant create(final Binary data, final PersistenceLoadHandler handler)
+	{
+		return Instant.ofEpochMilli(data.read_long(0L));
+	}
+
+	@Override
+	public final void updateState(final Binary data, final Instant instance, final PersistenceLoadHandler handler)
+	{
+		// no-op
+	}
+
+}

--- a/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerLocalDate.java
+++ b/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerLocalDate.java
@@ -32,6 +32,7 @@ public final class BinaryHandlerLocalDate extends AbstractBinaryHandlerCustomNon
 	static final long BINARY_OFFSET_YEAR  =                                  0L;
 	static final long BINARY_OFFSET_MONTH = BINARY_OFFSET_YEAR  + Integer.BYTES;
 	static final long BINARY_OFFSET_DAY   = BINARY_OFFSET_MONTH + Short  .BYTES;
+	static final long BINARY_LENGTH       = BINARY_OFFSET_DAY   + Short  .BYTES;
 	
 	///////////////////////////////////////////////////////////////////////////
 	// static methods //
@@ -75,7 +76,7 @@ public final class BinaryHandlerLocalDate extends AbstractBinaryHandlerCustomNon
 		final PersistenceStoreHandler<Binary> handler
 	)
 	{
-		data.storeEntityHeader(Long.BYTES, this.typeId(), objectId);
+		data.storeEntityHeader(BINARY_LENGTH, this.typeId(), objectId);
 		
 		data.store_int  (BINARY_OFFSET_YEAR , instance.getYear());
 		data.store_short(BINARY_OFFSET_MONTH, (short)instance.getMonthValue());

--- a/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerLocalDate.java
+++ b/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerLocalDate.java
@@ -1,0 +1,101 @@
+package one.microstream.persistence.binary.android.java.time;
+
+/*-
+ * #%L
+ * microstream-persistence-binary-android
+ * %%
+ * Copyright (C) 2019 - 2022 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is
+ * available at https://www.gnu.org/software/classpath/license.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * #L%
+ */
+
+import java.time.LocalDate;
+
+import one.microstream.persistence.binary.internal.AbstractBinaryHandlerCustomNonReferentialFixedLength;
+import one.microstream.persistence.binary.types.Binary;
+import one.microstream.persistence.types.PersistenceLoadHandler;
+import one.microstream.persistence.types.PersistenceStoreHandler;
+
+public final class BinaryHandlerLocalDate extends AbstractBinaryHandlerCustomNonReferentialFixedLength<LocalDate>
+{
+	static final long BINARY_OFFSET_YEAR  =                                  0L;
+	static final long BINARY_OFFSET_MONTH = BINARY_OFFSET_YEAR  + Integer.BYTES;
+	static final long BINARY_OFFSET_DAY   = BINARY_OFFSET_MONTH + Short  .BYTES;
+	
+	///////////////////////////////////////////////////////////////////////////
+	// static methods //
+	///////////////////
+	
+	public static BinaryHandlerLocalDate New()
+	{
+		return new BinaryHandlerLocalDate();
+	}
+
+	
+	
+	///////////////////////////////////////////////////////////////////////////
+	// constructors //
+	/////////////////
+
+	BinaryHandlerLocalDate()
+	{
+		super(
+			LocalDate.class,
+			CustomFields(
+				CustomField(int.class,   "year" ),
+				CustomField(short.class, "month"),
+				CustomField(short.class, "day"  )
+			)
+		);
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// methods //
+	////////////
+	
+
+	@Override
+	public final void store(
+		final Binary                          data    ,
+		final LocalDate                       instance,
+		final long                            objectId,
+		final PersistenceStoreHandler<Binary> handler
+	)
+	{
+		data.storeEntityHeader(Long.BYTES, this.typeId(), objectId);
+		
+		data.store_int  (BINARY_OFFSET_YEAR , instance.getYear());
+		data.store_short(BINARY_OFFSET_MONTH, (short)instance.getMonthValue());
+		data.store_short(BINARY_OFFSET_DAY  , (short)instance.getDayOfMonth());
+	}
+
+	@Override
+	public final LocalDate create(final Binary data, final PersistenceLoadHandler handler)
+	{
+		return LocalDate.of(
+			data.read_int  (BINARY_OFFSET_YEAR),
+			data.read_short(BINARY_OFFSET_MONTH),
+			data.read_short(BINARY_OFFSET_DAY)
+		);
+	}
+
+	@Override
+	public final void updateState(final Binary data, final LocalDate instance, final PersistenceLoadHandler handler)
+	{
+		// no-op
+	}
+
+}

--- a/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerLocalDateTime.java
+++ b/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerLocalDateTime.java
@@ -36,6 +36,7 @@ public final class BinaryHandlerLocalDateTime extends AbstractBinaryHandlerCusto
 	static final long BINARY_OFFSET_MINUTE = BINARY_OFFSET_HOUR   + Byte   .BYTES;
 	static final long BINARY_OFFSET_SECOND = BINARY_OFFSET_MINUTE + Byte   .BYTES;
 	static final long BINARY_OFFSET_NANO   = BINARY_OFFSET_SECOND + Byte   .BYTES;
+	static final long BINARY_LENGTH        = BINARY_OFFSET_NANO   + Integer.BYTES;
 	
 	///////////////////////////////////////////////////////////////////////////
 	// static methods //
@@ -83,7 +84,7 @@ public final class BinaryHandlerLocalDateTime extends AbstractBinaryHandlerCusto
 		final PersistenceStoreHandler<Binary> handler
 	)
 	{
-		data.storeEntityHeader(Long.BYTES, this.typeId(), objectId);
+		data.storeEntityHeader(BINARY_LENGTH, this.typeId(), objectId);
 		
 		data.store_int  (BINARY_OFFSET_YEAR  , instance.getYear());
 		data.store_short(BINARY_OFFSET_MONTH , (short)instance.getMonthValue());

--- a/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerLocalDateTime.java
+++ b/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerLocalDateTime.java
@@ -1,0 +1,117 @@
+package one.microstream.persistence.binary.android.java.time;
+
+/*-
+ * #%L
+ * microstream-persistence-binary-android
+ * %%
+ * Copyright (C) 2019 - 2022 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is
+ * available at https://www.gnu.org/software/classpath/license.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * #L%
+ */
+
+import java.time.LocalDateTime;
+
+import one.microstream.persistence.binary.internal.AbstractBinaryHandlerCustomNonReferentialFixedLength;
+import one.microstream.persistence.binary.types.Binary;
+import one.microstream.persistence.types.PersistenceLoadHandler;
+import one.microstream.persistence.types.PersistenceStoreHandler;
+
+public final class BinaryHandlerLocalDateTime extends AbstractBinaryHandlerCustomNonReferentialFixedLength<LocalDateTime>
+{
+	static final long BINARY_OFFSET_YEAR   =                                   0L;
+	static final long BINARY_OFFSET_MONTH  = BINARY_OFFSET_YEAR   + Integer.BYTES;
+	static final long BINARY_OFFSET_DAY    = BINARY_OFFSET_MONTH  + Short  .BYTES;
+	static final long BINARY_OFFSET_HOUR   = BINARY_OFFSET_DAY    + Short  .BYTES;
+	static final long BINARY_OFFSET_MINUTE = BINARY_OFFSET_HOUR   + Byte   .BYTES;
+	static final long BINARY_OFFSET_SECOND = BINARY_OFFSET_MINUTE + Byte   .BYTES;
+	static final long BINARY_OFFSET_NANO   = BINARY_OFFSET_SECOND + Byte   .BYTES;
+	
+	///////////////////////////////////////////////////////////////////////////
+	// static methods //
+	///////////////////
+	
+	public static BinaryHandlerLocalDateTime New()
+	{
+		return new BinaryHandlerLocalDateTime();
+	}
+
+	
+	
+	///////////////////////////////////////////////////////////////////////////
+	// constructors //
+	/////////////////
+
+	BinaryHandlerLocalDateTime()
+	{
+		super(
+			LocalDateTime.class,
+			CustomFields(
+				CustomField(int.class,   "year"  ),
+				CustomField(short.class, "month" ),
+				CustomField(short.class, "day"   ),
+				CustomField(byte.class,  "hour"  ),
+				CustomField(byte.class,  "minute"),
+				CustomField(byte.class,  "second"),
+				CustomField(int.class ,  "nano"  )
+			)
+		);
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// methods //
+	////////////
+	
+
+	@Override
+	public final void store(
+		final Binary                          data    ,
+		final LocalDateTime                   instance,
+		final long                            objectId,
+		final PersistenceStoreHandler<Binary> handler
+	)
+	{
+		data.storeEntityHeader(Long.BYTES, this.typeId(), objectId);
+		
+		data.store_int  (BINARY_OFFSET_YEAR  , instance.getYear());
+		data.store_short(BINARY_OFFSET_MONTH , (short)instance.getMonthValue());
+		data.store_short(BINARY_OFFSET_DAY   , (short)instance.getDayOfMonth());
+		data.store_byte (BINARY_OFFSET_HOUR  , (byte)instance.getHour());
+		data.store_byte (BINARY_OFFSET_MINUTE, (byte)instance.getMinute());
+		data.store_byte (BINARY_OFFSET_SECOND, (byte)instance.getSecond());
+		data.store_int  (BINARY_OFFSET_NANO  , instance.getNano());
+	}
+
+	@Override
+	public final LocalDateTime create(final Binary data, final PersistenceLoadHandler handler)
+	{
+		return LocalDateTime.of(
+			data.read_int  (BINARY_OFFSET_YEAR),
+			data.read_short(BINARY_OFFSET_MONTH),
+			data.read_short(BINARY_OFFSET_DAY),
+			data.read_byte (BINARY_OFFSET_HOUR),
+			data.read_byte (BINARY_OFFSET_MINUTE),
+			data.read_byte (BINARY_OFFSET_SECOND),
+			data.read_int  (BINARY_OFFSET_NANO)
+		);
+	}
+
+	@Override
+	public final void updateState(final Binary data, final LocalDateTime instance, final PersistenceLoadHandler handler)
+	{
+		// no-op
+	}
+
+}

--- a/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerLocalTime.java
+++ b/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerLocalTime.java
@@ -1,0 +1,105 @@
+package one.microstream.persistence.binary.android.java.time;
+
+/*-
+ * #%L
+ * microstream-persistence-binary-android
+ * %%
+ * Copyright (C) 2019 - 2022 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is
+ * available at https://www.gnu.org/software/classpath/license.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * #L%
+ */
+
+import java.time.LocalTime;
+
+import one.microstream.persistence.binary.internal.AbstractBinaryHandlerCustomNonReferentialFixedLength;
+import one.microstream.persistence.binary.types.Binary;
+import one.microstream.persistence.types.PersistenceLoadHandler;
+import one.microstream.persistence.types.PersistenceStoreHandler;
+
+public final class BinaryHandlerLocalTime extends AbstractBinaryHandlerCustomNonReferentialFixedLength<LocalTime>
+{
+	static final long BINARY_OFFSET_HOUR   =                                0L;
+	static final long BINARY_OFFSET_MINUTE = BINARY_OFFSET_HOUR   + Byte.BYTES;
+	static final long BINARY_OFFSET_SECOND = BINARY_OFFSET_MINUTE + Byte.BYTES;
+	static final long BINARY_OFFSET_NANO   = BINARY_OFFSET_SECOND + Byte.BYTES;
+	
+	///////////////////////////////////////////////////////////////////////////
+	// static methods //
+	///////////////////
+	
+	public static BinaryHandlerLocalTime New()
+	{
+		return new BinaryHandlerLocalTime();
+	}
+
+	
+	
+	///////////////////////////////////////////////////////////////////////////
+	// constructors //
+	/////////////////
+
+	BinaryHandlerLocalTime()
+	{
+		super(
+			LocalTime.class,
+			CustomFields(
+				CustomField(byte.class, "hour"  ),
+				CustomField(byte.class, "minute"),
+				CustomField(byte.class, "second"),
+				CustomField(int.class , "nano"  )
+			)
+		);
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// methods //
+	////////////
+	
+
+	@Override
+	public final void store(
+		final Binary                          data    ,
+		final LocalTime                       instance,
+		final long                            objectId,
+		final PersistenceStoreHandler<Binary> handler
+	)
+	{
+		data.storeEntityHeader(Long.BYTES, this.typeId(), objectId);
+		
+		data.store_byte(BINARY_OFFSET_HOUR  , (byte)instance.getHour());
+		data.store_byte(BINARY_OFFSET_MINUTE, (byte)instance.getMinute());
+		data.store_byte(BINARY_OFFSET_SECOND, (byte)instance.getSecond());
+		data.store_int (BINARY_OFFSET_NANO  , instance.getNano());
+	}
+
+	@Override
+	public final LocalTime create(final Binary data, final PersistenceLoadHandler handler)
+	{
+		return LocalTime.of(
+			data.read_byte(BINARY_OFFSET_HOUR),
+			data.read_byte(BINARY_OFFSET_MINUTE),
+			data.read_byte(BINARY_OFFSET_SECOND),
+			data.read_int (BINARY_OFFSET_NANO)
+		);
+	}
+
+	@Override
+	public final void updateState(final Binary data, final LocalTime instance, final PersistenceLoadHandler handler)
+	{
+		// no-op
+	}
+
+}

--- a/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerLocalTime.java
+++ b/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerLocalTime.java
@@ -29,10 +29,11 @@ import one.microstream.persistence.types.PersistenceStoreHandler;
 
 public final class BinaryHandlerLocalTime extends AbstractBinaryHandlerCustomNonReferentialFixedLength<LocalTime>
 {
-	static final long BINARY_OFFSET_HOUR   =                                0L;
-	static final long BINARY_OFFSET_MINUTE = BINARY_OFFSET_HOUR   + Byte.BYTES;
-	static final long BINARY_OFFSET_SECOND = BINARY_OFFSET_MINUTE + Byte.BYTES;
-	static final long BINARY_OFFSET_NANO   = BINARY_OFFSET_SECOND + Byte.BYTES;
+	static final long BINARY_OFFSET_HOUR   =                                   0L;
+	static final long BINARY_OFFSET_MINUTE = BINARY_OFFSET_HOUR   + Byte   .BYTES;
+	static final long BINARY_OFFSET_SECOND = BINARY_OFFSET_MINUTE + Byte   .BYTES;
+	static final long BINARY_OFFSET_NANO   = BINARY_OFFSET_SECOND + Byte   .BYTES;
+	static final long BINARY_LENGTH        = BINARY_OFFSET_NANO   + Integer.BYTES;
 	
 	///////////////////////////////////////////////////////////////////////////
 	// static methods //
@@ -77,7 +78,7 @@ public final class BinaryHandlerLocalTime extends AbstractBinaryHandlerCustomNon
 		final PersistenceStoreHandler<Binary> handler
 	)
 	{
-		data.storeEntityHeader(Long.BYTES, this.typeId(), objectId);
+		data.storeEntityHeader(BINARY_LENGTH, this.typeId(), objectId);
 		
 		data.store_byte(BINARY_OFFSET_HOUR  , (byte)instance.getHour());
 		data.store_byte(BINARY_OFFSET_MINUTE, (byte)instance.getMinute());

--- a/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerMonthDay.java
+++ b/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerMonthDay.java
@@ -1,0 +1,97 @@
+package one.microstream.persistence.binary.android.java.time;
+
+/*-
+ * #%L
+ * microstream-persistence-binary-android
+ * %%
+ * Copyright (C) 2019 - 2022 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is
+ * available at https://www.gnu.org/software/classpath/license.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * #L%
+ */
+
+import java.time.MonthDay;
+
+import one.microstream.persistence.binary.internal.AbstractBinaryHandlerCustomNonReferentialFixedLength;
+import one.microstream.persistence.binary.types.Binary;
+import one.microstream.persistence.types.PersistenceLoadHandler;
+import one.microstream.persistence.types.PersistenceStoreHandler;
+
+public final class BinaryHandlerMonthDay extends AbstractBinaryHandlerCustomNonReferentialFixedLength<MonthDay>
+{
+	static final long BINARY_OFFSET_MONTH =                                   0L;
+	static final long BINARY_OFFSET_DAY   = BINARY_OFFSET_MONTH  + Integer.BYTES;
+	
+	///////////////////////////////////////////////////////////////////////////
+	// static methods //
+	///////////////////
+	
+	public static BinaryHandlerMonthDay New()
+	{
+		return new BinaryHandlerMonthDay();
+	}
+
+	
+	
+	///////////////////////////////////////////////////////////////////////////
+	// constructors //
+	/////////////////
+
+	BinaryHandlerMonthDay()
+	{
+		super(
+			MonthDay.class,
+			CustomFields(
+				CustomField(int.class, "month"),
+				CustomField(int.class, "day"  )
+			)
+		);
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// methods //
+	////////////
+	
+
+	@Override
+	public final void store(
+		final Binary                          data    ,
+		final MonthDay                        instance,
+		final long                            objectId,
+		final PersistenceStoreHandler<Binary> handler
+	)
+	{
+		data.storeEntityHeader(Long.BYTES, this.typeId(), objectId);
+		
+		data.store_int(BINARY_OFFSET_MONTH, instance.getMonthValue());
+		data.store_int(BINARY_OFFSET_DAY  , instance.getDayOfMonth());
+	}
+
+	@Override
+	public final MonthDay create(final Binary data, final PersistenceLoadHandler handler)
+	{
+		return MonthDay.of(
+			data.read_int(BINARY_OFFSET_MONTH),
+			data.read_int(BINARY_OFFSET_DAY)
+		);
+	}
+
+	@Override
+	public final void updateState(final Binary data, final MonthDay instance, final PersistenceLoadHandler handler)
+	{
+		// no-op
+	}
+
+}

--- a/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerMonthDay.java
+++ b/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerMonthDay.java
@@ -29,8 +29,9 @@ import one.microstream.persistence.types.PersistenceStoreHandler;
 
 public final class BinaryHandlerMonthDay extends AbstractBinaryHandlerCustomNonReferentialFixedLength<MonthDay>
 {
-	static final long BINARY_OFFSET_MONTH =                                   0L;
-	static final long BINARY_OFFSET_DAY   = BINARY_OFFSET_MONTH  + Integer.BYTES;
+	static final long BINARY_OFFSET_MONTH =                                  0L;
+	static final long BINARY_OFFSET_DAY   = BINARY_OFFSET_MONTH + Integer.BYTES;
+	static final long BINARY_LENGTH       = BINARY_OFFSET_DAY   + Integer.BYTES;
 	
 	///////////////////////////////////////////////////////////////////////////
 	// static methods //
@@ -73,7 +74,7 @@ public final class BinaryHandlerMonthDay extends AbstractBinaryHandlerCustomNonR
 		final PersistenceStoreHandler<Binary> handler
 	)
 	{
-		data.storeEntityHeader(Long.BYTES, this.typeId(), objectId);
+		data.storeEntityHeader(BINARY_LENGTH, this.typeId(), objectId);
 		
 		data.store_int(BINARY_OFFSET_MONTH, instance.getMonthValue());
 		data.store_int(BINARY_OFFSET_DAY  , instance.getDayOfMonth());

--- a/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerOffsetDateTime.java
+++ b/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerOffsetDateTime.java
@@ -38,6 +38,7 @@ public final class BinaryHandlerOffsetDateTime extends AbstractBinaryHandlerCust
 	static final long BINARY_OFFSET_SECOND = BINARY_OFFSET_MINUTE + Byte   .BYTES;
 	static final long BINARY_OFFSET_NANO   = BINARY_OFFSET_SECOND + Byte   .BYTES;
 	static final long BINARY_OFFSET_OFFSET = BINARY_OFFSET_NANO   + Integer.BYTES;
+	static final long BINARY_LENGTH        = BINARY_OFFSET_OFFSET + Integer.BYTES;
 	
 	///////////////////////////////////////////////////////////////////////////
 	// static methods //
@@ -86,7 +87,7 @@ public final class BinaryHandlerOffsetDateTime extends AbstractBinaryHandlerCust
 		final PersistenceStoreHandler<Binary> handler
 	)
 	{
-		data.storeEntityHeader(Long.BYTES, this.typeId(), objectId);
+		data.storeEntityHeader(BINARY_LENGTH, this.typeId(), objectId);
 		
 		data.store_int  (BINARY_OFFSET_YEAR  , instance.getYear());
 		data.store_short(BINARY_OFFSET_MONTH , (short)instance.getMonthValue());

--- a/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerOffsetDateTime.java
+++ b/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerOffsetDateTime.java
@@ -1,0 +1,122 @@
+package one.microstream.persistence.binary.android.java.time;
+
+/*-
+ * #%L
+ * microstream-persistence-binary-android
+ * %%
+ * Copyright (C) 2019 - 2022 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is
+ * available at https://www.gnu.org/software/classpath/license.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * #L%
+ */
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import one.microstream.persistence.binary.internal.AbstractBinaryHandlerCustomNonReferentialFixedLength;
+import one.microstream.persistence.binary.types.Binary;
+import one.microstream.persistence.types.PersistenceLoadHandler;
+import one.microstream.persistence.types.PersistenceStoreHandler;
+
+public final class BinaryHandlerOffsetDateTime extends AbstractBinaryHandlerCustomNonReferentialFixedLength<OffsetDateTime>
+{
+	static final long BINARY_OFFSET_YEAR   =                                   0L;
+	static final long BINARY_OFFSET_MONTH  = BINARY_OFFSET_YEAR   + Integer.BYTES;
+	static final long BINARY_OFFSET_DAY    = BINARY_OFFSET_MONTH  + Short  .BYTES;
+	static final long BINARY_OFFSET_HOUR   = BINARY_OFFSET_DAY    + Short  .BYTES;
+	static final long BINARY_OFFSET_MINUTE = BINARY_OFFSET_HOUR   + Byte   .BYTES;
+	static final long BINARY_OFFSET_SECOND = BINARY_OFFSET_MINUTE + Byte   .BYTES;
+	static final long BINARY_OFFSET_NANO   = BINARY_OFFSET_SECOND + Byte   .BYTES;
+	static final long BINARY_OFFSET_OFFSET = BINARY_OFFSET_NANO   + Integer.BYTES;
+	
+	///////////////////////////////////////////////////////////////////////////
+	// static methods //
+	///////////////////
+	
+	public static BinaryHandlerOffsetDateTime New()
+	{
+		return new BinaryHandlerOffsetDateTime();
+	}
+
+	
+	
+	///////////////////////////////////////////////////////////////////////////
+	// constructors //
+	/////////////////
+
+	BinaryHandlerOffsetDateTime()
+	{
+		super(
+			OffsetDateTime.class,
+			CustomFields(
+				CustomField(int.class,   "year"  ),
+				CustomField(short.class, "month" ),
+				CustomField(short.class, "day"   ),
+				CustomField(byte.class,  "hour"  ),
+				CustomField(byte.class,  "minute"),
+				CustomField(byte.class,  "second"),
+				CustomField(int.class ,  "nano"  ),
+				CustomField(int.class ,  "offset")
+			)
+		);
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// methods //
+	////////////
+	
+
+	@Override
+	public final void store(
+		final Binary                          data    ,
+		final OffsetDateTime                   instance,
+		final long                            objectId,
+		final PersistenceStoreHandler<Binary> handler
+	)
+	{
+		data.storeEntityHeader(Long.BYTES, this.typeId(), objectId);
+		
+		data.store_int  (BINARY_OFFSET_YEAR  , instance.getYear());
+		data.store_short(BINARY_OFFSET_MONTH , (short)instance.getMonthValue());
+		data.store_short(BINARY_OFFSET_DAY   , (short)instance.getDayOfMonth());
+		data.store_byte (BINARY_OFFSET_HOUR  , (byte)instance.getHour());
+		data.store_byte (BINARY_OFFSET_MINUTE, (byte)instance.getMinute());
+		data.store_byte (BINARY_OFFSET_SECOND, (byte)instance.getSecond());
+		data.store_int  (BINARY_OFFSET_NANO  , instance.getNano());
+		data.store_int  (BINARY_OFFSET_OFFSET, instance.getOffset().getTotalSeconds());
+	}
+
+	@Override
+	public final OffsetDateTime create(final Binary data, final PersistenceLoadHandler handler)
+	{
+		return OffsetDateTime.of(
+			data.read_int  (BINARY_OFFSET_YEAR),
+			data.read_short(BINARY_OFFSET_MONTH),
+			data.read_short(BINARY_OFFSET_DAY),
+			data.read_byte (BINARY_OFFSET_HOUR),
+			data.read_byte (BINARY_OFFSET_MINUTE),
+			data.read_byte (BINARY_OFFSET_SECOND),
+			data.read_int  (BINARY_OFFSET_NANO),
+			ZoneOffset.ofTotalSeconds(data.read_int(BINARY_OFFSET_OFFSET))
+		);
+	}
+
+	@Override
+	public final void updateState(final Binary data, final OffsetDateTime instance, final PersistenceLoadHandler handler)
+	{
+		// no-op
+	}
+
+}

--- a/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerOffsetTime.java
+++ b/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerOffsetTime.java
@@ -1,0 +1,110 @@
+package one.microstream.persistence.binary.android.java.time;
+
+/*-
+ * #%L
+ * microstream-persistence-binary-android
+ * %%
+ * Copyright (C) 2019 - 2022 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is
+ * available at https://www.gnu.org/software/classpath/license.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * #L%
+ */
+
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+
+import one.microstream.persistence.binary.internal.AbstractBinaryHandlerCustomNonReferentialFixedLength;
+import one.microstream.persistence.binary.types.Binary;
+import one.microstream.persistence.types.PersistenceLoadHandler;
+import one.microstream.persistence.types.PersistenceStoreHandler;
+
+public final class BinaryHandlerOffsetTime extends AbstractBinaryHandlerCustomNonReferentialFixedLength<OffsetTime>
+{
+	static final long BINARY_OFFSET_HOUR   =                                   0L;
+	static final long BINARY_OFFSET_MINUTE = BINARY_OFFSET_HOUR   + Byte   .BYTES;
+	static final long BINARY_OFFSET_SECOND = BINARY_OFFSET_MINUTE + Byte   .BYTES;
+	static final long BINARY_OFFSET_NANO   = BINARY_OFFSET_SECOND + Byte   .BYTES;
+	static final long BINARY_OFFSET_OFFSET = BINARY_OFFSET_NANO   + Integer.BYTES;
+	
+	///////////////////////////////////////////////////////////////////////////
+	// static methods //
+	///////////////////
+	
+	public static BinaryHandlerOffsetTime New()
+	{
+		return new BinaryHandlerOffsetTime();
+	}
+
+	
+	
+	///////////////////////////////////////////////////////////////////////////
+	// constructors //
+	/////////////////
+
+	BinaryHandlerOffsetTime()
+	{
+		super(
+			OffsetTime.class,
+			CustomFields(
+				CustomField(byte.class, "hour"  ),
+				CustomField(byte.class, "minute"),
+				CustomField(byte.class, "second"),
+				CustomField(int.class , "nano"  ),
+				CustomField(int.class , "offset")
+			)
+		);
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// methods //
+	////////////
+	
+
+	@Override
+	public final void store(
+		final Binary                          data    ,
+		final OffsetTime                       instance,
+		final long                            objectId,
+		final PersistenceStoreHandler<Binary> handler
+	)
+	{
+		data.storeEntityHeader(Long.BYTES, this.typeId(), objectId);
+		
+		data.store_byte(BINARY_OFFSET_HOUR  , (byte)instance.getHour());
+		data.store_byte(BINARY_OFFSET_MINUTE, (byte)instance.getMinute());
+		data.store_byte(BINARY_OFFSET_SECOND, (byte)instance.getSecond());
+		data.store_int (BINARY_OFFSET_NANO  , instance.getNano());
+		data.store_int (BINARY_OFFSET_OFFSET, instance.getOffset().getTotalSeconds());
+	}
+
+	@Override
+	public final OffsetTime create(final Binary data, final PersistenceLoadHandler handler)
+	{
+		return OffsetTime.of(
+			data.read_byte(BINARY_OFFSET_HOUR),
+			data.read_byte(BINARY_OFFSET_MINUTE),
+			data.read_byte(BINARY_OFFSET_SECOND),
+			data.read_int(BINARY_OFFSET_NANO),
+			ZoneOffset.ofTotalSeconds(data.read_int(BINARY_OFFSET_OFFSET))
+		);
+	}
+
+	@Override
+	public final void updateState(final Binary data, final OffsetTime instance, final PersistenceLoadHandler handler)
+	{
+		// no-op
+	}
+
+}

--- a/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerOffsetTime.java
+++ b/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerOffsetTime.java
@@ -35,6 +35,7 @@ public final class BinaryHandlerOffsetTime extends AbstractBinaryHandlerCustomNo
 	static final long BINARY_OFFSET_SECOND = BINARY_OFFSET_MINUTE + Byte   .BYTES;
 	static final long BINARY_OFFSET_NANO   = BINARY_OFFSET_SECOND + Byte   .BYTES;
 	static final long BINARY_OFFSET_OFFSET = BINARY_OFFSET_NANO   + Integer.BYTES;
+	static final long BINARY_LENGTH        = BINARY_OFFSET_OFFSET + Integer.BYTES;
 	
 	///////////////////////////////////////////////////////////////////////////
 	// static methods //
@@ -80,7 +81,7 @@ public final class BinaryHandlerOffsetTime extends AbstractBinaryHandlerCustomNo
 		final PersistenceStoreHandler<Binary> handler
 	)
 	{
-		data.storeEntityHeader(Long.BYTES, this.typeId(), objectId);
+		data.storeEntityHeader(BINARY_LENGTH, this.typeId(), objectId);
 		
 		data.store_byte(BINARY_OFFSET_HOUR  , (byte)instance.getHour());
 		data.store_byte(BINARY_OFFSET_MINUTE, (byte)instance.getMinute());

--- a/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerPeriod.java
+++ b/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerPeriod.java
@@ -32,6 +32,7 @@ public final class BinaryHandlerPeriod extends AbstractBinaryHandlerCustomNonRef
 	static final long BINARY_OFFSET_YEARS  =                                   0L;
 	static final long BINARY_OFFSET_MONTHS = BINARY_OFFSET_YEARS  + Integer.BYTES;
 	static final long BINARY_OFFSET_DAYS   = BINARY_OFFSET_MONTHS + Integer.BYTES;
+	static final long BINARY_LENGTH        = BINARY_OFFSET_DAYS   + Integer.BYTES;
 	
 	///////////////////////////////////////////////////////////////////////////
 	// static methods //
@@ -75,7 +76,7 @@ public final class BinaryHandlerPeriod extends AbstractBinaryHandlerCustomNonRef
 		final PersistenceStoreHandler<Binary> handler
 	)
 	{
-		data.storeEntityHeader(Long.BYTES, this.typeId(), objectId);
+		data.storeEntityHeader(BINARY_LENGTH, this.typeId(), objectId);
 		
 		data.store_int(BINARY_OFFSET_YEARS , instance.getYears());
 		data.store_int(BINARY_OFFSET_MONTHS, instance.getMonths());

--- a/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerPeriod.java
+++ b/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerPeriod.java
@@ -1,0 +1,101 @@
+package one.microstream.persistence.binary.android.java.time;
+
+/*-
+ * #%L
+ * microstream-persistence-binary-android
+ * %%
+ * Copyright (C) 2019 - 2022 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is
+ * available at https://www.gnu.org/software/classpath/license.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * #L%
+ */
+
+import java.time.Period;
+
+import one.microstream.persistence.binary.internal.AbstractBinaryHandlerCustomNonReferentialFixedLength;
+import one.microstream.persistence.binary.types.Binary;
+import one.microstream.persistence.types.PersistenceLoadHandler;
+import one.microstream.persistence.types.PersistenceStoreHandler;
+
+public final class BinaryHandlerPeriod extends AbstractBinaryHandlerCustomNonReferentialFixedLength<Period>
+{
+	static final long BINARY_OFFSET_YEARS  =                                   0L;
+	static final long BINARY_OFFSET_MONTHS = BINARY_OFFSET_YEARS  + Integer.BYTES;
+	static final long BINARY_OFFSET_DAYS   = BINARY_OFFSET_MONTHS + Integer.BYTES;
+	
+	///////////////////////////////////////////////////////////////////////////
+	// static methods //
+	///////////////////
+	
+	public static BinaryHandlerPeriod New()
+	{
+		return new BinaryHandlerPeriod();
+	}
+
+	
+	
+	///////////////////////////////////////////////////////////////////////////
+	// constructors //
+	/////////////////
+
+	BinaryHandlerPeriod()
+	{
+		super(
+			Period.class,
+			CustomFields(
+				CustomField(int.class, "years" ),
+				CustomField(int.class, "months"),
+				CustomField(int.class, "days"  )
+			)
+		);
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// methods //
+	////////////
+	
+
+	@Override
+	public final void store(
+		final Binary                          data    ,
+		final Period                          instance,
+		final long                            objectId,
+		final PersistenceStoreHandler<Binary> handler
+	)
+	{
+		data.storeEntityHeader(Long.BYTES, this.typeId(), objectId);
+		
+		data.store_int(BINARY_OFFSET_YEARS , instance.getYears());
+		data.store_int(BINARY_OFFSET_MONTHS, instance.getMonths());
+		data.store_int(BINARY_OFFSET_DAYS  , instance.getDays());
+	}
+
+	@Override
+	public final Period create(final Binary data, final PersistenceLoadHandler handler)
+	{
+		return Period.of(
+			data.read_int(BINARY_OFFSET_YEARS),
+			data.read_int(BINARY_OFFSET_MONTHS),
+			data.read_int(BINARY_OFFSET_DAYS)
+		);
+	}
+
+	@Override
+	public final void updateState(final Binary data, final Period instance, final PersistenceLoadHandler handler)
+	{
+		// no-op
+	}
+
+}

--- a/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerYear.java
+++ b/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerYear.java
@@ -1,0 +1,89 @@
+package one.microstream.persistence.binary.android.java.time;
+
+/*-
+ * #%L
+ * microstream-persistence-binary-android
+ * %%
+ * Copyright (C) 2019 - 2022 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is
+ * available at https://www.gnu.org/software/classpath/license.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * #L%
+ */
+
+import java.time.Year;
+
+import one.microstream.persistence.binary.internal.AbstractBinaryHandlerCustomNonReferentialFixedLength;
+import one.microstream.persistence.binary.types.Binary;
+import one.microstream.persistence.types.PersistenceLoadHandler;
+import one.microstream.persistence.types.PersistenceStoreHandler;
+
+public final class BinaryHandlerYear extends AbstractBinaryHandlerCustomNonReferentialFixedLength<Year>
+{
+	///////////////////////////////////////////////////////////////////////////
+	// static methods //
+	///////////////////
+	
+	public static BinaryHandlerYear New()
+	{
+		return new BinaryHandlerYear();
+	}
+
+	
+	
+	///////////////////////////////////////////////////////////////////////////
+	// constructors //
+	/////////////////
+
+	BinaryHandlerYear()
+	{
+		super(
+			Year.class,
+			CustomFields(
+				CustomField(int.class, "year")
+			)
+		);
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// methods //
+	////////////
+	
+
+	@Override
+	public final void store(
+		final Binary                          data    ,
+		final Year                            instance,
+		final long                            objectId,
+		final PersistenceStoreHandler<Binary> handler
+	)
+	{
+		data.storeEntityHeader(Long.BYTES, this.typeId(), objectId);
+		
+		data.store_long(instance.getValue());
+	}
+
+	@Override
+	public final Year create(final Binary data, final PersistenceLoadHandler handler)
+	{
+		return Year.of(data.read_int(0L));
+	}
+
+	@Override
+	public final void updateState(final Binary data, final Year instance, final PersistenceLoadHandler handler)
+	{
+		// no-op
+	}
+
+}

--- a/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerYear.java
+++ b/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerYear.java
@@ -69,7 +69,7 @@ public final class BinaryHandlerYear extends AbstractBinaryHandlerCustomNonRefer
 		final PersistenceStoreHandler<Binary> handler
 	)
 	{
-		data.storeEntityHeader(Long.BYTES, this.typeId(), objectId);
+		data.storeEntityHeader(Integer.BYTES, this.typeId(), objectId);
 		
 		data.store_long(instance.getValue());
 	}

--- a/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerYearMonth.java
+++ b/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerYearMonth.java
@@ -31,6 +31,7 @@ public final class BinaryHandlerYearMonth extends AbstractBinaryHandlerCustomNon
 {
 	static final long BINARY_OFFSET_YEAR  =                                  0L;
 	static final long BINARY_OFFSET_MONTH = BINARY_OFFSET_YEAR  + Integer.BYTES;
+	static final long BINARY_LENGTH       = BINARY_OFFSET_MONTH + Integer.BYTES;
 	
 	///////////////////////////////////////////////////////////////////////////
 	// static methods //
@@ -73,7 +74,7 @@ public final class BinaryHandlerYearMonth extends AbstractBinaryHandlerCustomNon
 		final PersistenceStoreHandler<Binary> handler
 	)
 	{
-		data.storeEntityHeader(Long.BYTES, this.typeId(), objectId);
+		data.storeEntityHeader(BINARY_LENGTH, this.typeId(), objectId);
 
 		data.store_int(BINARY_OFFSET_YEAR , instance.getYear());
 		data.store_int(BINARY_OFFSET_MONTH, instance.getMonthValue());

--- a/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerYearMonth.java
+++ b/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerYearMonth.java
@@ -1,0 +1,97 @@
+package one.microstream.persistence.binary.android.java.time;
+
+/*-
+ * #%L
+ * microstream-persistence-binary-android
+ * %%
+ * Copyright (C) 2019 - 2022 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is
+ * available at https://www.gnu.org/software/classpath/license.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * #L%
+ */
+
+import java.time.YearMonth;
+
+import one.microstream.persistence.binary.internal.AbstractBinaryHandlerCustomNonReferentialFixedLength;
+import one.microstream.persistence.binary.types.Binary;
+import one.microstream.persistence.types.PersistenceLoadHandler;
+import one.microstream.persistence.types.PersistenceStoreHandler;
+
+public final class BinaryHandlerYearMonth extends AbstractBinaryHandlerCustomNonReferentialFixedLength<YearMonth>
+{
+	static final long BINARY_OFFSET_YEAR  =                                  0L;
+	static final long BINARY_OFFSET_MONTH = BINARY_OFFSET_YEAR  + Integer.BYTES;
+	
+	///////////////////////////////////////////////////////////////////////////
+	// static methods //
+	///////////////////
+	
+	public static BinaryHandlerYearMonth New()
+	{
+		return new BinaryHandlerYearMonth();
+	}
+
+	
+	
+	///////////////////////////////////////////////////////////////////////////
+	// constructors //
+	/////////////////
+
+	BinaryHandlerYearMonth()
+	{
+		super(
+			YearMonth.class,
+			CustomFields(
+				CustomField(int.class, "year" ),
+				CustomField(int.class, "month")
+			)
+		);
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// methods //
+	////////////
+	
+
+	@Override
+	public final void store(
+		final Binary                          data    ,
+		final YearMonth                       instance,
+		final long                            objectId,
+		final PersistenceStoreHandler<Binary> handler
+	)
+	{
+		data.storeEntityHeader(Long.BYTES, this.typeId(), objectId);
+
+		data.store_int(BINARY_OFFSET_YEAR , instance.getYear());
+		data.store_int(BINARY_OFFSET_MONTH, instance.getMonthValue());
+	}
+
+	@Override
+	public final YearMonth create(final Binary data, final PersistenceLoadHandler handler)
+	{
+		return YearMonth.of(
+			data.read_int(BINARY_OFFSET_YEAR),
+			data.read_int(BINARY_OFFSET_MONTH)
+		);
+	}
+
+	@Override
+	public final void updateState(final Binary data, final YearMonth instance, final PersistenceLoadHandler handler)
+	{
+		// no-op
+	}
+
+}

--- a/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerZonedDateTime.java
+++ b/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerZonedDateTime.java
@@ -1,0 +1,133 @@
+package one.microstream.persistence.binary.android.java.time;
+
+/*-
+ * #%L
+ * microstream-persistence-binary-android
+ * %%
+ * Copyright (C) 2019 - 2022 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is
+ * available at https://www.gnu.org/software/classpath/license.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * #L%
+ */
+
+import java.time.ZonedDateTime;
+import java.time.ZoneId;
+import one.microstream.persistence.binary.internal.AbstractBinaryHandlerCustomNonReferential;
+import one.microstream.persistence.binary.types.Binary;
+import one.microstream.persistence.types.PersistenceLoadHandler;
+import one.microstream.persistence.types.PersistenceStoreHandler;
+
+public final class BinaryHandlerZonedDateTime extends AbstractBinaryHandlerCustomNonReferential<ZonedDateTime>
+{
+	static final long BINARY_OFFSET_YEAR   =                                   0L;
+	static final long BINARY_OFFSET_MONTH  = BINARY_OFFSET_YEAR   + Integer.BYTES;
+	static final long BINARY_OFFSET_DAY    = BINARY_OFFSET_MONTH  + Short  .BYTES;
+	static final long BINARY_OFFSET_HOUR   = BINARY_OFFSET_DAY    + Short  .BYTES;
+	static final long BINARY_OFFSET_MINUTE = BINARY_OFFSET_HOUR   + Byte   .BYTES;
+	static final long BINARY_OFFSET_SECOND = BINARY_OFFSET_MINUTE + Byte   .BYTES;
+	static final long BINARY_OFFSET_NANO   = BINARY_OFFSET_SECOND + Byte   .BYTES;
+	static final long BINARY_OFFSET_ID     = BINARY_OFFSET_NANO   + Integer.BYTES;
+	
+	///////////////////////////////////////////////////////////////////////////
+	// static methods //
+	///////////////////
+	
+	public static BinaryHandlerZonedDateTime New()
+	{
+		return new BinaryHandlerZonedDateTime();
+	}
+
+	
+	
+	///////////////////////////////////////////////////////////////////////////
+	// constructors //
+	/////////////////
+
+	BinaryHandlerZonedDateTime()
+	{
+		super(
+			ZonedDateTime.class,
+			CustomFields(
+				CustomField(int.class,   "year"  ),
+				CustomField(short.class, "month" ),
+				CustomField(short.class, "day"   ),
+				CustomField(byte.class,  "hour"  ),
+				CustomField(byte.class,  "minute"),
+				CustomField(byte.class,  "second"),
+				CustomField(int.class ,  "nano"  ),
+				chars("id")
+			)
+		);
+	}
+
+
+
+	///////////////////////////////////////////////////////////////////////////
+	// methods //
+	////////////
+	
+
+	@Override
+	public final void store(
+		final Binary                          data    ,
+		final ZonedDateTime                   instance,
+		final long                            objectId,
+		final PersistenceStoreHandler<Binary> handler
+	)
+	{
+		data.storeEntityHeader(Long.BYTES, this.typeId(), objectId);
+		
+		data.store_int       (BINARY_OFFSET_YEAR  , instance.getYear());
+		data.store_short     (BINARY_OFFSET_MONTH , (short)instance.getMonthValue());
+		data.store_short     (BINARY_OFFSET_DAY   , (short)instance.getDayOfMonth());
+		data.store_byte      (BINARY_OFFSET_HOUR  , (byte)instance.getHour());
+		data.store_byte      (BINARY_OFFSET_MINUTE, (byte)instance.getMinute());
+		data.store_byte      (BINARY_OFFSET_SECOND, (byte)instance.getSecond());
+		data.store_int       (BINARY_OFFSET_NANO  , instance.getNano());
+		data.storeStringValue(BINARY_OFFSET_ID    , instance.getZone().getId());
+	}
+
+	@Override
+	public final ZonedDateTime create(final Binary data, final PersistenceLoadHandler handler)
+	{
+		return ZonedDateTime.of(
+			data.read_int  (BINARY_OFFSET_YEAR),
+			data.read_short(BINARY_OFFSET_MONTH),
+			data.read_short(BINARY_OFFSET_DAY),
+			data.read_byte (BINARY_OFFSET_HOUR),
+			data.read_byte (BINARY_OFFSET_MINUTE),
+			data.read_byte (BINARY_OFFSET_SECOND),
+			data.read_int  (BINARY_OFFSET_NANO),
+			ZoneId.of(data.buildString(BINARY_OFFSET_ID))
+		);
+	}
+
+	@Override
+	public final void updateState(final Binary data, final ZonedDateTime instance, final PersistenceLoadHandler handler)
+	{
+		// no-op
+	}
+
+	@Override
+	public final boolean hasPersistedVariableLength()
+	{
+		return true;
+	}
+	
+	@Override
+	public final boolean hasVaryingPersistedLengthInstances()
+	{
+		return true;
+	}
+
+}

--- a/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerZonedDateTime.java
+++ b/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/java/time/BinaryHandlerZonedDateTime.java
@@ -85,7 +85,10 @@ public final class BinaryHandlerZonedDateTime extends AbstractBinaryHandlerCusto
 		final PersistenceStoreHandler<Binary> handler
 	)
 	{
-		data.storeEntityHeader(Long.BYTES, this.typeId(), objectId);
+		final String zoneId              = instance.getZone().getId();
+		final long   entityContentLength = BINARY_OFFSET_ID + Binary.calculateBinaryLengthChars(zoneId.length());
+		
+		data.storeEntityHeader(entityContentLength, this.typeId(), objectId);
 		
 		data.store_int       (BINARY_OFFSET_YEAR  , instance.getYear());
 		data.store_short     (BINARY_OFFSET_MONTH , (short)instance.getMonthValue());
@@ -94,7 +97,7 @@ public final class BinaryHandlerZonedDateTime extends AbstractBinaryHandlerCusto
 		data.store_byte      (BINARY_OFFSET_MINUTE, (byte)instance.getMinute());
 		data.store_byte      (BINARY_OFFSET_SECOND, (byte)instance.getSecond());
 		data.store_int       (BINARY_OFFSET_NANO  , instance.getNano());
-		data.storeStringValue(BINARY_OFFSET_ID    , instance.getZone().getId());
+		data.storeStringValue(BINARY_OFFSET_ID    , zoneId);
 	}
 
 	@Override

--- a/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/types/BinaryHandlersAndroid.java
+++ b/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/types/BinaryHandlersAndroid.java
@@ -39,8 +39,8 @@ import one.microstream.persistence.types.PersistenceFoundation;
 /**
  * Registeres special type handlers written for Android.
  * Some of them have to sacrifice referencial integrity for funcionality.
- * 
- * @see https://github.com/microstream-one/microstream/issues/245#issuecomment-921660371
+ * <p>
+ * See <a href="https://github.com/microstream-one/microstream/issues/245#issuecomment-921660371">Issue</a> for further details.
  */
 public final class BinaryHandlersAndroid
 {

--- a/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/types/BinaryHandlersAndroid.java
+++ b/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/types/BinaryHandlersAndroid.java
@@ -1,0 +1,68 @@
+package one.microstream.persistence.binary.android.types;
+
+/*-
+ * #%L
+ * microstream-persistence-binary-android
+ * %%
+ * Copyright (C) 2019 - 2022 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is
+ * available at https://www.gnu.org/software/classpath/license.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * #L%
+ */
+
+import one.microstream.X;
+import one.microstream.persistence.binary.android.java.time.BinaryHandlerDuration;
+import one.microstream.persistence.binary.android.java.time.BinaryHandlerInstant;
+import one.microstream.persistence.binary.android.java.time.BinaryHandlerLocalDate;
+import one.microstream.persistence.binary.android.java.time.BinaryHandlerLocalDateTime;
+import one.microstream.persistence.binary.android.java.time.BinaryHandlerLocalTime;
+import one.microstream.persistence.binary.android.java.time.BinaryHandlerMonthDay;
+import one.microstream.persistence.binary.android.java.time.BinaryHandlerOffsetDateTime;
+import one.microstream.persistence.binary.android.java.time.BinaryHandlerOffsetTime;
+import one.microstream.persistence.binary.android.java.time.BinaryHandlerPeriod;
+import one.microstream.persistence.binary.android.java.time.BinaryHandlerYear;
+import one.microstream.persistence.binary.android.java.time.BinaryHandlerYearMonth;
+import one.microstream.persistence.binary.android.java.time.BinaryHandlerZonedDateTime;
+import one.microstream.persistence.binary.types.Binary;
+import one.microstream.persistence.types.PersistenceFoundation;
+
+/**
+ * Registeres special type handlers written for Android.
+ * Some of them have to sacrifice referencial integrity for funcionality.
+ * 
+ * @see https://github.com/microstream-one/microstream/issues/245#issuecomment-921660371
+ */
+public final class BinaryHandlersAndroid
+{
+	public static <F extends PersistenceFoundation<Binary, ?>> F registerAndroidTypeHandlers(final F foundation)
+	{
+		foundation.executeTypeHandlerRegistration((r, c) ->
+			r.registerTypeHandlers(X.List(
+				BinaryHandlerDuration.New(),
+				BinaryHandlerInstant.New(),
+				BinaryHandlerLocalDate.New(),
+				BinaryHandlerLocalTime.New(),
+				BinaryHandlerLocalDateTime.New(),
+				BinaryHandlerMonthDay.New(),
+				BinaryHandlerOffsetTime.New(),
+				BinaryHandlerOffsetDateTime.New(),
+				BinaryHandlerPeriod.New(),
+				BinaryHandlerYear.New(),
+				BinaryHandlerYearMonth.New(),
+				BinaryHandlerZonedDateTime.New()
+			))
+		);
+		
+		return foundation;
+	}
+}

--- a/persistence/binary-android/src/module-info.java
+++ b/persistence/binary-android/src/module-info.java
@@ -1,0 +1,28 @@
+/*-
+ * #%L
+ * microstream-persistence-binary-android
+ * %%
+ * Copyright (C) 2019 - 2022 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is
+ * available at https://www.gnu.org/software/classpath/license.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * #L%
+ */
+module microstream.persistence.binary.android
+{
+	exports one.microstream.persistence.binary.android.types;
+	exports one.microstream.persistence.binary.android.java.time;
+	
+	requires microstream.base;
+	requires microstream.persistence;
+	requires microstream.persistence.binary;
+}

--- a/persistence/pom.xml
+++ b/persistence/pom.xml
@@ -23,6 +23,7 @@
         <module>persistence</module>
         <module>binary</module>
         <module>binary-jdk8</module>
+        <module>binary-android</module>
     </modules>
 
     <profiles>


### PR DESCRIPTION
Special type handlers for common java.time types for Android. This is necessary due to reflection restrictions in newer Android versions. See #245 for further details.