### PR TITLE
Check for cache clear after loading storage entities

### DIFF
--- a/storage/storage/src/main/java/one/microstream/storage/types/StorageChannel.java
+++ b/storage/storage/src/main/java/one/microstream/storage/types/StorageChannel.java
@@ -849,6 +849,7 @@ public interface StorageChannel extends Runnable, StorageChannelResetablePart, S
 				throw new StorageExceptionConsistency("No entity found for objectId " + objectId);
 			}
 			entry.copyCachedData(this.dataCollector);
+			this.entityCache.checkForCacheClear(entry, System.currentTimeMillis());
 		}
 
 	}
@@ -898,6 +899,7 @@ public interface StorageChannel extends Runnable, StorageChannelResetablePart, S
 			for(StorageEntity.Default entity = type.head; (entity = entity.typeNext) != null;)
 			{
 				entity.copyCachedData(this.dataCollector);
+				this.entityCache.checkForCacheClear(entity, System.currentTimeMillis());
 			}
 		}
 

--- a/storage/storage/src/main/java/one/microstream/storage/types/StorageEntityCache.java
+++ b/storage/storage/src/main/java/one/microstream/storage/types/StorageEntityCache.java
@@ -873,7 +873,7 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 			entity.setDeleted();
 		}
 
-		private void checkForCacheClear(final StorageEntity.Default entry, final long evalTime)
+		void checkForCacheClear(final StorageEntity.Default entry, final long evalTime)
 		{
 			if(this.entityCacheEvaluator.clearEntityCache(this.usedCacheSize, evalTime, entry))
 			{


### PR DESCRIPTION
Currently the load by oid & tid tasks load all entities into the storage entity cache during storage initialization. This fix will stop the cache from expanding further than the limit specified in the storage entity cache evaluator.