### PR TITLE
explicit DirectByteBuffer deallocation

### DIFF
--- a/base/src/main/java/one/microstream/typing/Disposable.java
+++ b/base/src/main/java/one/microstream/typing/Disposable.java
@@ -1,4 +1,4 @@
-package one.microstream.storage.types;
+package one.microstream.typing;
 
 /*-
  * #%L
@@ -20,7 +20,7 @@ package one.microstream.storage.types;
  * #L%
  */
 
-public interface Destroyable 
+public interface Disposable 
 {
 	/**
 	 * Release resources used by the implementing class
@@ -28,6 +28,6 @@ public interface Destroyable
 	 * 
 	 * After calling, the owning object may be in an inoperable state which it can't recover from! 
 	 */
-	public void destroy();
+	public void dispose();
 	
 }

--- a/base/src/main/java/one/microstream/typing/Disposable.java
+++ b/base/src/main/java/one/microstream/typing/Disposable.java
@@ -2,7 +2,7 @@ package one.microstream.typing;
 
 /*-
  * #%L
- * MicroStream Storage
+ * MicroStream Base
  * %%
  * Copyright (C) 2019 - 2022 MicroStream Software
  * %%

--- a/storage/storage/src/main/java/one/microstream/storage/types/Destroyable.java
+++ b/storage/storage/src/main/java/one/microstream/storage/types/Destroyable.java
@@ -1,0 +1,33 @@
+package one.microstream.storage.types;
+
+/*-
+ * #%L
+ * MicroStream Storage
+ * %%
+ * Copyright (C) 2019 - 2022 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is
+ * available at https://www.gnu.org/software/classpath/license.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * #L%
+ */
+
+public interface Destroyable 
+{
+	/**
+	 * Release resources used by the implementing class
+	 * that should be released before the garbage collector takes care of them.
+	 * 
+	 * After calling, the owning object may be in an inoperable state which it can't recover from! 
+	 */
+	public void destroy();
+	
+}

--- a/storage/storage/src/main/java/one/microstream/storage/types/StorageChannel.java
+++ b/storage/storage/src/main/java/one/microstream/storage/types/StorageChannel.java
@@ -41,12 +41,13 @@ import one.microstream.persistence.types.PersistenceIdSet;
 import one.microstream.persistence.types.Unpersistable;
 import one.microstream.storage.exceptions.StorageExceptionConsistency;
 import one.microstream.time.XTime;
+import one.microstream.typing.Disposable;
 import one.microstream.typing.KeyValue;
 import one.microstream.util.BufferSizeProviderIncremental;
 import one.microstream.util.logging.Logging;
 
 
-public interface StorageChannel extends Runnable, StorageChannelResetablePart, StorageActivePart, Destroyable
+public interface StorageChannel extends Runnable, StorageChannelResetablePart, StorageActivePart, Disposable
 {
 	public StorageTypeDictionary typeDictionary();
 
@@ -539,7 +540,7 @@ public interface StorageChannel extends Runnable, StorageChannelResetablePart, S
 			{
 				try
 				{
-					this.destroy();
+					this.dispose();
 				}
 				catch(final Throwable t1)
 				{
@@ -795,10 +796,10 @@ public interface StorageChannel extends Runnable, StorageChannelResetablePart, S
 		}
 
 		@Override
-		public final void destroy()
+		public final void dispose()
 		{
 			this.entityCache.reset();
-			this.fileManager.destroy();
+			this.fileManager.dispose();
 		}
 	}
 

--- a/storage/storage/src/main/java/one/microstream/storage/types/StorageChannel.java
+++ b/storage/storage/src/main/java/one/microstream/storage/types/StorageChannel.java
@@ -46,7 +46,7 @@ import one.microstream.util.BufferSizeProviderIncremental;
 import one.microstream.util.logging.Logging;
 
 
-public interface StorageChannel extends Runnable, StorageChannelResetablePart, StorageActivePart
+public interface StorageChannel extends Runnable, StorageChannelResetablePart, StorageActivePart, Destroyable
 {
 	public StorageTypeDictionary typeDictionary();
 
@@ -539,7 +539,7 @@ public interface StorageChannel extends Runnable, StorageChannelResetablePart, S
 			{
 				try
 				{
-					this.reset();
+					this.destroy();
 				}
 				catch(final Throwable t1)
 				{
@@ -794,6 +794,12 @@ public interface StorageChannel extends Runnable, StorageChannelResetablePart, S
 			this.entityCache.clearPendingStoreUpdate();
 		}
 
+		@Override
+		public final void destroy()
+		{
+			this.entityCache.reset();
+			this.fileManager.destroy();
+		}
 	}
 
 

--- a/storage/storage/src/main/java/one/microstream/storage/types/StorageEntityInitializer.java
+++ b/storage/storage/src/main/java/one/microstream/storage/types/StorageEntityInitializer.java
@@ -115,6 +115,8 @@ public interface StorageEntityInitializer<D extends StorageLiveDataFile>
 				registerFileEntities(entityCache, initTime, dataFile, dataFile.size(), buffer, entityOffsets);
 			}
 			
+			XMemory.deallocateDirectByteBuffer(buffer);
+			
 			return headFile;
 		}
 		

--- a/storage/storage/src/main/java/one/microstream/storage/types/StorageFileManager.java
+++ b/storage/storage/src/main/java/one/microstream/storage/types/StorageFileManager.java
@@ -47,13 +47,14 @@ import one.microstream.storage.exceptions.StorageExceptionIoWriting;
 import one.microstream.storage.exceptions.StorageExceptionIoWritingChunk;
 import one.microstream.storage.types.StorageRawFileStatistics.FileStatistics;
 import one.microstream.storage.types.StorageTransactionsAnalysis.EntryAggregator;
+import one.microstream.typing.Disposable;
 import one.microstream.typing.XTypes;
 import one.microstream.util.BufferSizeProvider;
 import one.microstream.util.logging.Logging;
 
 
 // note that the name channel refers to the entity hash channel, not an nio channel
-public interface StorageFileManager extends StorageChannelResetablePart, Destroyable
+public interface StorageFileManager extends StorageChannelResetablePart, Disposable
 {
 	/* (17.09.2014 TM)TODO: Much more loose coupling
 	 * Make all storage stuff much more loosely coupled with more interface methods and
@@ -269,7 +270,7 @@ public interface StorageFileManager extends StorageChannelResetablePart, Destroy
 		////////////
 
 		@Override
-		public final void destroy()
+		public final void dispose()
 		{
 			this.clearRegisteredFiles();
 			this.deleteBuffers();
@@ -924,7 +925,7 @@ public interface StorageFileManager extends StorageChannelResetablePart, Destroy
 			catch(final RuntimeException e)
 			{
 				//as this instance won't be restarted any more, destroy allocated buffers
-				parent.destroy();
+				parent.dispose();
 				throw e;
 			}
 			finally

--- a/storage/storage/src/main/java/one/microstream/storage/types/StorageFileManager.java
+++ b/storage/storage/src/main/java/one/microstream/storage/types/StorageFileManager.java
@@ -28,6 +28,8 @@ import static one.microstream.math.XMath.notNegative;
 import java.nio.ByteBuffer;
 import java.util.function.Consumer;
 
+import org.slf4j.Logger;
+
 import one.microstream.X;
 import one.microstream.afs.types.AFS;
 import one.microstream.afs.types.AFile;
@@ -47,10 +49,11 @@ import one.microstream.storage.types.StorageRawFileStatistics.FileStatistics;
 import one.microstream.storage.types.StorageTransactionsAnalysis.EntryAggregator;
 import one.microstream.typing.XTypes;
 import one.microstream.util.BufferSizeProvider;
+import one.microstream.util.logging.Logging;
 
 
 // note that the name channel refers to the entity hash channel, not an nio channel
-public interface StorageFileManager extends StorageChannelResetablePart
+public interface StorageFileManager extends StorageChannelResetablePart, Destroyable
 {
 	/* (17.09.2014 TM)TODO: Much more loose coupling
 	 * Make all storage stuff much more loosely coupled with more interface methods and
@@ -107,6 +110,8 @@ public interface StorageFileManager extends StorageChannelResetablePart
 
 	public final class Default implements StorageFileManager, StorageFileUser
 	{
+		private final static Logger logger = Logging.getLogger(Default.class);
+		
 		///////////////////////////////////////////////////////////////////////////
 		// constants //
 		//////////////
@@ -262,7 +267,14 @@ public interface StorageFileManager extends StorageChannelResetablePart
 		///////////////////////////////////////////////////////////////////////////
 		// methods //
 		////////////
-		
+
+		@Override
+		public final void destroy()
+		{
+			this.clearRegisteredFiles();
+			this.deleteBuffers();
+		}
+
 		final boolean isFileCleanupEnabled()
 		{
 			return this.writeController.isFileCleanupEnabled();
@@ -911,8 +923,8 @@ public interface StorageFileManager extends StorageChannelResetablePart
 			}
 			catch(final RuntimeException e)
 			{
-				// on any exception, reset (clear) the internal state
-				parent.reset();
+				//as this instance won't be restarted any more, destroy allocated buffers
+				parent.destroy();
 				throw e;
 			}
 			finally
@@ -1276,6 +1288,24 @@ public interface StorageFileManager extends StorageChannelResetablePart
 			// at this point, it is either 0 already or it won't matter since everything has been cleared.
 			this.pendingFileDeletes = 0;
 		}
+		
+		/**
+		 * The deleteBuffers method is used to allow an early deallocation
+		 * of the used DirectByteBuffers in order to reduce the off-heap
+		 * memory footprint without the need to relay on the GC.
+		 * after calling this method the StorageManager is left in a inoperable state.
+		 */
+		public final void deleteBuffers()
+		{
+			logger.debug("Destroying all buffers explicitly!");
+
+			XMemory.deallocateDirectByteBuffer(this.entryBufferFileCreation);
+			XMemory.deallocateDirectByteBuffer(this.entryBufferStore);
+			XMemory.deallocateDirectByteBuffer(this.entryBufferTransfer);
+			XMemory.deallocateDirectByteBuffer(this.entryBufferFileDeletion);
+			XMemory.deallocateDirectByteBuffer(this.entryBufferFileTruncation);
+			XMemory.deallocateDirectByteBuffer(this.standardByteBuffer);
+		}
 
 		final void handleLastFile(
 			final StorageLiveDataFile.Default lastFile      ,
@@ -1593,7 +1623,7 @@ public interface StorageFileManager extends StorageChannelResetablePart
 			{
 				if(file.head.fileNext != startingFile.tail)
 				{
-					if(file.hasContent()) 
+					if(file.hasContent())
 					{
 						return file.head.fileNext;
 					}


### PR DESCRIPTION
Explcitly deallocate ByteBuffers to reduce the memory usage on restarts done by the remote storage feature.
