### PR TITLE
Fixing internal issue 616: LegacyTypeMapping causes error if GC enabled

### DIFF
--- a/storage/storage/src/main/java/one/microstream/storage/types/StorageEntityCache.java
+++ b/storage/storage/src/main/java/one/microstream/storage/types/StorageEntityCache.java
@@ -660,14 +660,20 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 			 * the byte order switching for storage usage. Should the need arise in the future, additional
 			 * time can be invested to solve this.
 			 */
-			
-//			DEBUGStorage.println("looking for " + Binary.getEntityObjectId(entityAddress));
+								
 			final StorageEntity.Default entry;
 			if((entry = this.getEntry(Binary.getEntityObjectIdRawValue(entityAddress))) != null)
 			{
-//				DEBUGStorage.println("updating entry " + entry);
-				this.resetExistingEntityForUpdate(entry);
-				return entry;
+				final long entityTypeId = Binary.getEntityTypeIdRawValue(entityAddress);
+				if(entry.typeId() == entityTypeId) {
+					this.resetExistingEntityForUpdate(entry);
+					return entry;
+				}
+				
+				logger.debug("Entity {} typeId changed, old: {}, new: {}",
+					entry.objectId(),
+					entry.typeId(),
+					entityTypeId);
 			}
 
 //			DEBUGStorage.println("creating " + Binary.getEntityObjectId(entityAddress) + ", " + Binary.getEntityTypeId(entityAddress) + ", [" + Binary.getEntityLength(entityAddress) + "]");
@@ -861,6 +867,8 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 			final StorageEntity.Default     previousInType
 		)
 		{
+			logger.debug("Deleting entity {}, typeId: {}", entity.objectId(), entity.typeId());
+			
 			// 1.) unregister entity from hash table (= unfindable by future requests)
 			this.unregisterEntity(entity);
 


### PR DESCRIPTION
please note that the StorageEntityCache GC has to be enabled for testing