### PR TITLE
Use "one.microstream." as prefix for MicroProfile Configuration keys 

### DIFF
--- a/examples/cdi-javase/src/main/resources/META-INF/microprofile-config.properties
+++ b/examples/cdi-javase/src/main/resources/META-INF/microprofile-config.properties
@@ -1,4 +1,4 @@
 
-microstream.storage.directory=target/data
-microstream.channel.count=4
-microstream.store=true
+one.microstream.storage.directory=target/data
+one.microstream.channel.count=4
+one.microstream.store=true

--- a/examples/helidon-mp/src/main/resources/META-INF/microprofile-config.properties
+++ b/examples/helidon-mp/src/main/resources/META-INF/microprofile-config.properties
@@ -9,5 +9,5 @@ server.static.classpath.location=/WEB
 #server.static.classpath.welcome=index.html
 
 #microstream
-microstream.storage.directory=target/data
-microstream.channel.count=4
+one.microstream.storage.directory=target/data
+one.microstream.channel.count=4

--- a/examples/payara-micro/src/main/resources/META-INF/microprofile-config.properties
+++ b/examples/payara-micro/src/main/resources/META-INF/microprofile-config.properties
@@ -1,4 +1,4 @@
 
 #microstream
-microstream.storage.directory=target/data
-microstream.channel.count=4
+one.microstream.storage.directory=target/data
+one.microstream.channel.count=4

--- a/examples/wildfly/src/main/resources/META-INF/microprofile-config.properties
+++ b/examples/wildfly/src/main/resources/META-INF/microprofile-config.properties
@@ -1,5 +1,5 @@
 
 
 #microstream
-microstream.storage.directory=target/data
-microstream.channel.count=4
+one.microstream.storage.directory=target/data
+one.microstream.channel.count=4

--- a/integrations/cdi/README.md
+++ b/integrations/cdi/README.md
@@ -218,7 +218,7 @@ The relation with the properties from [Microstream docs](https://docs.microstrea
 * ```one.microstream.transaction.file.prefix```: transaction-file-prefix; Name prefix of the storage transaction file. Default is "transactions_".
 * ```one.microstream.transaction.file.suffix```: transaction-file-suffix; Name suffix of the storage transaction file. Default is ".sft".
 * ```one.microstream.type.dictionary.file.name```: type-dictionary-file-name; The name of the dictionary file. Default is "PersistenceTypeDictionary.ptd".
-* ```microstream.rescued.file.suffix```: rescued-file-suffix; Name suffix of the storage rescue files. Default is ".bak".
+* ```one.microstream.rescued.file.suffix```: rescued-file-suffix; Name suffix of the storage rescue files. Default is ".bak".
 * ```one.microstream.lock.file.name```: lock-file-name; Name of the lock file. Default is "used.lock".
 * ```one.microstream.housekeeping.interval```: housekeeping-interval; Interval for the housekeeping. This is work like garbage collection or cache checking. In combination with houseKeepingNanoTimeBudget the maximum processor time for housekeeping work can be set. Default is 1 second.
 * ```one.microstream.housekeeping.time.budget```: housekeeping-time-budget; Number of nanoseconds used for each housekeeping cycle. Default is 10 milliseconds = 0.01 seconds.

--- a/integrations/cdi/README.md
+++ b/integrations/cdi/README.md
@@ -187,15 +187,15 @@ It will use the Eclipse Microprofile to read/parse the properties.
 
 ```java
 @Inject
-private NameStorage names;
+private StorageManager manager;
 ```
 
-This injection will look in the ```microprofile-config.properties``` file to the property that will be a file to load directly by Micrscrostream with the ``EmbeddedStorageConfiguration.load(value);`` method.
+This injection will look in the ```microprofile-config.properties``` file to the property that will be a file to load directly by Microstream with the ``EmbeddedStorageConfiguration.load(value);`` method.
 
 ```java
 @Inject
-@ConfigProperty(name = "microstream.ini")
-private NameStorage names;
+@ConfigProperty(name = "one.microstream.ini")
+private StorageManager manager;
 ```
 
 
@@ -205,30 +205,30 @@ private NameStorage names;
 
 The relation with the properties from [Microstream docs](https://docs.microstream.one/manual/storage/configuration/properties.html):
 
-* ```microstream.storage.directory```: storage-directory; The base directory of the storage in the file system. Default is "storage" in the working directory.
-* ```microstream.storage.filesystem```: storage-filesystem; The live file system configuration. See storage targets configuration.
-* ```microstream.deletion.directory```: deletion-directory; If configured, the storage will not delete files. Instead of deleting a file it will be moved to this directory.
-* ```microstream.truncation.directory```: truncation-directory; If configured, files that will get truncated are copied into this directory.
-* ```microstream.backup.directory```: backup-directory; The backup directory.
-* ```microstream.backup.filesystem```: backup-filesystem; The backup file system configuration. See storage targets configuration.
-* ```microstream.channel.count```: channel-count; The number of threads and number of directories used by the storage engine. Every thread has exclusive access to its directory. Default is 1.
-* ```microstream.channel.directory.prefix```: channel-directory-prefix; Name prefix of the subdirectories used by the channel threads. Default is "channel_".
-* ```microstream.data.file.prefix```: data-file-prefix; Name prefix of the storage files. Default is "channel_".
-* ```microstream.data.file.suffix```: data-file-suffix; Name suffix of the storage files. Default is ".dat".
-* ```microstream.transaction.file.prefix```: transaction-file-prefix; Name prefix of the storage transaction file. Default is "transactions_".
-* ```microstream.transaction.file.suffix```: transaction-file-suffix; Name suffix of the storage transaction file. Default is ".sft".
-* ```microstream.type.dictionary.file.name```: type-dictionary-file-name; The name of the dictionary file. Default is "PersistenceTypeDictionary.ptd".
+* ```one.microstream.storage.directory```: storage-directory; The base directory of the storage in the file system. Default is "storage" in the working directory.
+* ```one.microstream.storage.filesystem```: storage-filesystem; The live file system configuration. See storage targets configuration.
+* ```one.microstream.deletion.directory```: deletion-directory; If configured, the storage will not delete files. Instead of deleting a file it will be moved to this directory.
+* ```one.microstream.truncation.directory```: truncation-directory; If configured, files that will get truncated are copied into this directory.
+* ```one.microstream.backup.directory```: backup-directory; The backup directory.
+* ```one.microstream.backup.filesystem```: backup-filesystem; The backup file system configuration. See storage targets configuration.
+* ```one.microstream.channel.count```: channel-count; The number of threads and number of directories used by the storage engine. Every thread has exclusive access to its directory. Default is 1.
+* ```one.microstream.channel.directory.prefix```: channel-directory-prefix; Name prefix of the subdirectories used by the channel threads. Default is "channel_".
+* ```one.microstream.data.file.prefix```: data-file-prefix; Name prefix of the storage files. Default is "channel_".
+* ```one.microstream.data.file.suffix```: data-file-suffix; Name suffix of the storage files. Default is ".dat".
+* ```one.microstream.transaction.file.prefix```: transaction-file-prefix; Name prefix of the storage transaction file. Default is "transactions_".
+* ```one.microstream.transaction.file.suffix```: transaction-file-suffix; Name suffix of the storage transaction file. Default is ".sft".
+* ```one.microstream.type.dictionary.file.name```: type-dictionary-file-name; The name of the dictionary file. Default is "PersistenceTypeDictionary.ptd".
 * ```microstream.rescued.file.suffix```: rescued-file-suffix; Name suffix of the storage rescue files. Default is ".bak".
-* ```microstream.lock.file.name```: lock-file-name; Name of the lock file. Default is "used.lock".
-* ```microstream.housekeeping.interval```: housekeeping-interval; Interval for the housekeeping. This is work like garbage collection or cache checking. In combination with houseKeepingNanoTimeBudget the maximum processor time for housekeeping work can be set. Default is 1 second.
-* ```microstream.housekeeping.time.budget```: housekeeping-time-budget; Number of nanoseconds used for each housekeeping cycle. Default is 10 milliseconds = 0.01 seconds.
-* ```microstream.entity.cache.threshold```: entity-cache-threshold; Abstract threshold value for the lifetime of entities in the cache. Default is 1000000000.
-* ```microstream.entity.cache.timeout```: entity-cache-timeout; Timeout in milliseconds for the entity cache evaluator. If an entity wasn’t accessed in this timespan it will be removed from the cache. Default is 1 day.
-* ```microstream.data.file.minimum.size```: data-file-minimum-size; Minimum file size for a data file to avoid cleaning it up. Default is 1024^2 = 1 MiB.
-* ```microstream.data.file.maximum.size```: data-file-maximum-size; Maximum file size for a data file to avoid cleaning it up. Default is 1024^2*8 = 8 MiB.
-* ```microstream.data.file.minimum.use.ratio```: data-file-minimum-use-ratio; The ratio (value in ]0.0;1.0]) of non-gap data contained in a storage file to prevent the file from being dissolved. Default is 0.75 (75%).
-* ```microstream.data.file.cleanup.head.file```: data-file-cleanup-head-file; A flag defining whether the current head file (the only file actively written to) shall be subjected to file cleanups as well.
-* ```microstream.property```: llow custom properties in through Microprofile, using this prefix. E.g.: If you want to include the "custom.test" property, you will set it as "microstream.property.custom.test"
+* ```one.microstream.lock.file.name```: lock-file-name; Name of the lock file. Default is "used.lock".
+* ```one.microstream.housekeeping.interval```: housekeeping-interval; Interval for the housekeeping. This is work like garbage collection or cache checking. In combination with houseKeepingNanoTimeBudget the maximum processor time for housekeeping work can be set. Default is 1 second.
+* ```one.microstream.housekeeping.time.budget```: housekeeping-time-budget; Number of nanoseconds used for each housekeeping cycle. Default is 10 milliseconds = 0.01 seconds.
+* ```one.microstream.entity.cache.threshold```: entity-cache-threshold; Abstract threshold value for the lifetime of entities in the cache. Default is 1000000000.
+* ```one.microstream.entity.cache.timeout```: entity-cache-timeout; Timeout in milliseconds for the entity cache evaluator. If an entity wasn’t accessed in this timespan it will be removed from the cache. Default is 1 day.
+* ```one.microstream.data.file.minimum.size```: data-file-minimum-size; Minimum file size for a data file to avoid cleaning it up. Default is 1024^2 = 1 MiB.
+* ```one.microstream.data.file.maximum.size```: data-file-maximum-size; Maximum file size for a data file to avoid cleaning it up. Default is 1024^2*8 = 8 MiB.
+* ```one.microstream.data.file.minimum.use.ratio```: data-file-minimum-use-ratio; The ratio (value in ]0.0;1.0]) of non-gap data contained in a storage file to prevent the file from being dissolved. Default is 0.75 (75%).
+* ```one.microstream.data.file.cleanup.head.file```: data-file-cleanup-head-file; A flag defining whether the current head file (the only file actively written to) shall be subjected to file cleanups as well.
+* ```one.microstream.property```: Allow custom properties in through Microprofile, using this prefix. E.g.: If you want to include the "custom.test" property, you will set it as "one.microstream.property.custom.test"
 
 ### Cache
 

--- a/integrations/cdi/src/main/java/one/microstream/integrations/cdi/types/ConfigurationCoreProperties.java
+++ b/integrations/cdi/src/main/java/one/microstream/integrations/cdi/types/ConfigurationCoreProperties.java
@@ -32,7 +32,7 @@ import one.microstream.storage.embedded.configuration.types.EmbeddedStorageConfi
 
 
 /**
- * The relation with the properties from Microstream docs:
+ * The relation with the properties from MicroStream docs:
  * https://docs.microstream.one/manual/storage/configuration/properties.html
  */
 public enum ConfigurationCoreProperties
@@ -41,7 +41,7 @@ public enum ConfigurationCoreProperties
 	 * The base directory of the storage in the file system. Default is "storage" in the working directory.
 	 */
 	STORAGE_DIRECTORY(
-		"microstream.storage.directory",
+		Constants.PREFIX + "storage.directory",
 		EmbeddedStorageConfigurationPropertyNames.STORAGE_DIRECTORY
 	),
 	
@@ -49,7 +49,7 @@ public enum ConfigurationCoreProperties
 	 * The live file system configuration. See storage targets configuration.
 	 */
 	STORAGE_FILESYSTEM(
-		"microstream.storage.filesystem",
+			Constants.PREFIX + "storage.filesystem",
 		EmbeddedStorageConfigurationPropertyNames.STORAGE_FILESYSTEM
 	),
 	
@@ -57,7 +57,7 @@ public enum ConfigurationCoreProperties
 	 * If configured, the storage will not delete files. Instead of deleting a file it will be moved to this directory.
 	 */
 	DELETION_DIRECTORY(
-		"microstream.deletion.directory",
+			Constants.PREFIX + "deletion.directory",
 		EmbeddedStorageConfigurationPropertyNames.DELETION_DIRECTORY
 	),
 	
@@ -65,7 +65,7 @@ public enum ConfigurationCoreProperties
 	 * If configured, files that will get truncated are copied into this directory.
 	 */
 	TRUNCATION_DIRECTORY(
-		"microstream.truncation.directory",
+			Constants.PREFIX + "truncation.directory",
 		EmbeddedStorageConfigurationPropertyNames.TRUNCATION_DIRECTORY
 	),
 	
@@ -73,7 +73,7 @@ public enum ConfigurationCoreProperties
 	 * The backup directory.
 	 */
 	BACKUP_DIRECTORY(
-		"microstream.backup.directory",
+			Constants.PREFIX + "backup.directory",
 		EmbeddedStorageConfigurationPropertyNames.BACKUP_DIRECTORY
 	),
 	
@@ -81,7 +81,7 @@ public enum ConfigurationCoreProperties
 	 * The backup file system configuration. See storage targets configuration.
 	 */
 	BACKUP_FILESYSTEM(
-		"microstream.backup.filesystem",
+			Constants.PREFIX + "backup.filesystem",
 		EmbeddedStorageConfigurationPropertyNames.BACKUP_FILESYSTEM
 	),
 	
@@ -90,7 +90,7 @@ public enum ConfigurationCoreProperties
 	 * to its directory. Default is 1.
 	 */
 	CHANNEL_COUNT(
-		"microstream.channel.count",
+			Constants.PREFIX + "channel.count",
 		EmbeddedStorageConfigurationPropertyNames.CHANNEL_COUNT
 	),
 	
@@ -98,7 +98,7 @@ public enum ConfigurationCoreProperties
 	 * Name prefix of the subdirectories used by the channel threads. Default is "channel_".
 	 */
 	CHANNEL_DIRECTORY_PREFIX(
-		"microstream.channel.directory.prefix",
+			Constants.PREFIX + "channel.directory.prefix",
 		EmbeddedStorageConfigurationPropertyNames.CHANNEL_DIRECTORY_PREFIX
 	),
 	
@@ -106,7 +106,7 @@ public enum ConfigurationCoreProperties
 	 * Name prefix of the storage files. Default is "channel_".
 	 */
 	DATA_FILE_PREFIX(
-		"microstream.data.file.prefix",
+			Constants.PREFIX + "data.file.prefix",
 		EmbeddedStorageConfigurationPropertyNames.DATA_FILE_PREFIX
 	),
 	
@@ -114,7 +114,7 @@ public enum ConfigurationCoreProperties
 	 * Name suffix of the storage files. Default is ".dat".
 	 */
 	DATA_FILE_SUFFIX(
-		"microstream.data.file.suffix",
+			Constants.PREFIX + "data.file.suffix",
 		EmbeddedStorageConfigurationPropertyNames.DATA_FILE_SUFFIX
 	),
 	
@@ -122,7 +122,7 @@ public enum ConfigurationCoreProperties
 	 * Name prefix of the storage transaction file. Default is "transactions_".
 	 */
 	TRANSACTION_FILE_PREFIX(
-		"microstream.transaction.file.prefix",
+			Constants.PREFIX + "transaction.file.prefix",
 		EmbeddedStorageConfigurationPropertyNames.TRANSACTION_FILE_PREFIX
 	),
 	
@@ -130,7 +130,7 @@ public enum ConfigurationCoreProperties
 	 * Name suffix of the storage transaction file. Default is ".sft".
 	 */
 	TRANSACTION_FILE_SUFFIX(
-		"microstream.transaction.file.suffix",
+			Constants.PREFIX + "transaction.file.suffix",
 		EmbeddedStorageConfigurationPropertyNames.TRANSACTION_FILE_SUFFIX
 	),
 	
@@ -138,7 +138,7 @@ public enum ConfigurationCoreProperties
 	 * The name of the dictionary file. Default is "PersistenceTypeDictionary.ptd".
 	 */
 	TYPE_DICTIONARY_FILE_NAME(
-		"microstream.type.dictionary.file.name",
+			Constants.PREFIX + "type.dictionary.file.name",
 		EmbeddedStorageConfigurationPropertyNames.TYPE_DICTIONARY_FILE_NAME
 	),
 	
@@ -146,7 +146,7 @@ public enum ConfigurationCoreProperties
 	 * Name suffix of the storage rescue files. Default is ".bak".
 	 */
 	RESCUED_FILE_SUFFIX(
-		"microstream.rescued.file.suffix",
+			Constants.PREFIX + "rescued.file.suffix",
 		EmbeddedStorageConfigurationPropertyNames.RESCUED_FILE_SUFFIX
 	),
 	
@@ -154,7 +154,7 @@ public enum ConfigurationCoreProperties
 	 * Name of the lock file. Default is "used.lock".
 	 */
 	LOCK_FILE_NAME(
-		"microstream.lock.file.name",
+			Constants.PREFIX + "lock.file.name",
 		EmbeddedStorageConfigurationPropertyNames.LOCK_FILE_NAME
 	),
 	
@@ -163,7 +163,7 @@ public enum ConfigurationCoreProperties
 	 * houseKeepingNanoTimeBudget the maximum processor time for housekeeping work can be set. Default is 1 second.
 	 */
 	HOUSEKEEPING_INTERVAL(
-		"microstream.housekeeping.interval",
+			Constants.PREFIX + "housekeeping.interval",
 		EmbeddedStorageConfigurationPropertyNames.HOUSEKEEPING_INTERVAL
 	),
 	
@@ -171,7 +171,7 @@ public enum ConfigurationCoreProperties
 	 * Number of nanoseconds used for each housekeeping cycle. Default is 10 milliseconds = 0.01 seconds.
 	 */
 	HOUSEKEEPING_TIME_BUDGET(
-		"microstream.housekeeping.time.budget",
+			Constants.PREFIX + "housekeeping.time.budget",
 		EmbeddedStorageConfigurationPropertyNames.HOUSEKEEPING_TIME_BUDGET
 	),
 	
@@ -179,7 +179,7 @@ public enum ConfigurationCoreProperties
 	 * Abstract threshold value for the lifetime of entities in the cache. Default is 1000000000.
 	 */
 	ENTITY_CACHE_THRESHOLD(
-		"microstream.entity.cache.threshold",
+			Constants.PREFIX + "entity.cache.threshold",
 		EmbeddedStorageConfigurationPropertyNames.ENTITY_CACHE_THRESHOLD
 	),
 	
@@ -188,7 +188,7 @@ public enum ConfigurationCoreProperties
 	 * accessed in this timespan it will be removed from the cache. Default is 1 day.
 	 */
 	ENTITY_CACHE_TIMEOUT(
-		"microstream.entity.cache.timeout",
+			Constants.PREFIX + "entity.cache.timeout",
 		EmbeddedStorageConfigurationPropertyNames.ENTITY_CACHE_TIMEOUT
 	),
 	
@@ -196,7 +196,7 @@ public enum ConfigurationCoreProperties
 	 * Minimum file size for a data file to avoid cleaning it up. Default is 1024^2 = 1 MiB.
 	 */
 	DATA_FILE_MINIMUM_SIZE(
-		"microstream.data.file.minimum.size",
+			Constants.PREFIX + "data.file.minimum.size",
 		EmbeddedStorageConfigurationPropertyNames.DATA_FILE_MINIMUM_SIZE
 	),
 	
@@ -204,7 +204,7 @@ public enum ConfigurationCoreProperties
 	 * Maximum file size for a data file to avoid cleaning it up. Default is 1024^2*8 = 8 MiB.
 	 */
 	DATA_FILE_MAXIMUM_SIZE(
-		"microstream.data.file.maximum.size",
+			Constants.PREFIX + "data.file.maximum.size",
 		EmbeddedStorageConfigurationPropertyNames.DATA_FILE_MAXIMUM_SIZE
 	),
 	
@@ -213,7 +213,7 @@ public enum ConfigurationCoreProperties
 	 * dissolved. Default is 0.75 (75%).
 	 */
 	DATA_FILE_MINIMUM_USE_RATIO(
-		"microstream.data.file.minimum.use.ratio",
+			Constants.PREFIX + "data.file.minimum.use.ratio",
 		EmbeddedStorageConfigurationPropertyNames.DATA_FILE_MINIMUM_USE_RATIO
 	),
 	
@@ -222,19 +222,19 @@ public enum ConfigurationCoreProperties
 	 * shall be subjected to file cleanups as well.
 	 */
 	DATA_FILE_CLEANUP_HEAD_FILE(
-		"microstream.data.file.cleanup.head.file",
+			Constants.PREFIX + "data.file.cleanup.head.file",
 		EmbeddedStorageConfigurationPropertyNames.DATA_FILE_CLEANUP_HEAD_FILE
 	),
 	
 	/**
 	 * Allow custom properties in through Microprofile, using this prefix. E.g.:
-	 * If you want to include the "custom.test" property, you will set it as "microstream.property.custom.test"
+	 * If you want to include the "custom.test" property, you will set it as "one.microstream.property.custom.test"
 	 */
 	CUSTOM(
-		"microstream.property",
+			Constants.PREFIX + "property",
 		""
 	);
-	
+
 	private final String microprofile;
 	private final String microstream ;
 	
@@ -306,5 +306,10 @@ public enum ConfigurationCoreProperties
 		config.getOptionalValue(property.getMicroprofile(), String.class)
 			.ifPresent(v -> properties.put(property.getMicrostream(), v))
 		;
+	}
+
+	private static class Constants
+	{
+		static final String PREFIX = "one.microstream.";
 	}
 }

--- a/integrations/cdi/src/main/java/one/microstream/integrations/cdi/types/cache/CacheProperties.java
+++ b/integrations/cdi/src/main/java/one/microstream/integrations/cdi/types/cache/CacheProperties.java
@@ -40,49 +40,50 @@ import one.microstream.reflect.XReflect;
  */
 public enum CacheProperties implements Supplier<String>
 {
+	PREFIX("one.microstream."),
 	/**
 	 * cacheLoaderFactory - A CacheLoader should be configured
 	 * for "Read Through" caches to load values when a cache miss occurs.
 	 */
-	CACHE_LOADER_FACTORY("microstream.cache.loader.factory"),
+	CACHE_LOADER_FACTORY(PREFIX + "cache.loader.factory"),
 	/**
 	 * cacheWriterFactory - A CacheWriter is used for write-through to an external resource.
 	 */
-	CACHE_WRITER_FACTORY("microstream.cache.writer.factory"),
+	CACHE_WRITER_FACTORY(PREFIX + "cache.writer.factory"),
 	/**
 	 * expiryPolicyFactory - Determines when cache entries will expire based on creation,
 	 * access and modification operations.
 	 */
-	CACHE_EXPIRES_FACTORY("microstream.cache.expires.factory"),
+	CACHE_EXPIRES_FACTORY(PREFIX + "cache.expires.factory"),
 	/**
 	 * readThrough - When in "read-through" mode, cache misses that occur due to cache entries not existing
 	 * as a result of performing a "get" will appropriately cause the configured CacheLoader to be invoked.
 	 */
-	CACHE_READ_THROUGH("microstream.cache.read.through"),
+	CACHE_READ_THROUGH(PREFIX + "cache.read.through"),
 	/**
 	 * writeThrough - When in "write-through" mode, cache updates that occur as a result
 	 * of performing "put" operations will appropriately cause the configured CacheWriter to be invoked.
 	 */
-	CACHE_WRITE_THROUGH("microstream.cache.write.through"),
+	CACHE_WRITE_THROUGH(PREFIX + "cache.write.through"),
 	/**
 	 * storeByValue - When a cache is storeByValue,
 	 * any mutation to the key or value does not affect the key of value stored in the cache.
 	 */
-	CACHE_STORE_VALUE("microstream.cache.store.value"),
+	CACHE_STORE_VALUE(PREFIX + "cache.store.value"),
 	/**
 	 * statisticsEnabled - Checks whether statistics collection is enabled in this cache.
 	 */
-	CACHE_STATISTICS("microstream.cache.statistics"),
+	CACHE_STATISTICS(PREFIX + "cache.statistics"),
 	/**
 	 * managementEnabled - Checks whether management is enabled on this cache.
 	 */
-	CACHE_MANAGEMENT("microstream.cache.management"),
+	CACHE_MANAGEMENT(PREFIX + "cache.management"),
 	/**
 	 * MicroStream’s storage can be used as a backing store for the cache.
 	 * It functions as a CacheWriter as well as a CacheReader, depending on the writeThrough
 	 * and readThrough configuration. Per default it is used for both.
 	 */
-	STORAGE("microstream.store");
+	STORAGE(PREFIX + "store");
 	
 	private final String value;
 	

--- a/integrations/cdi/src/test/java/one/microstream/integrations/cdi/types/StorageManagerConverterINITest.java
+++ b/integrations/cdi/src/test/java/one/microstream/integrations/cdi/types/StorageManagerConverterINITest.java
@@ -36,7 +36,7 @@ import javax.inject.Inject;
 public class StorageManagerConverterINITest
 {
 	@Inject
-	@ConfigProperty(name = "microstream.ini")
+	@ConfigProperty(name = "one.microstream.ini")
 	private StorageManager manager;
 	
 	@Test

--- a/integrations/cdi/src/test/java/one/microstream/integrations/cdi/types/StorageManagerConverterPropertiesTest.java
+++ b/integrations/cdi/src/test/java/one/microstream/integrations/cdi/types/StorageManagerConverterPropertiesTest.java
@@ -36,7 +36,7 @@ import javax.inject.Inject;
 public class StorageManagerConverterPropertiesTest
 {
 	@Inject
-	@ConfigProperty(name = "microstream.properties")
+	@ConfigProperty(name = "one.microstream.properties")
 	private StorageManager manager;
 	
 	@Test

--- a/integrations/cdi/src/test/java/one/microstream/integrations/cdi/types/StorageManagerConverterXMLTest.java
+++ b/integrations/cdi/src/test/java/one/microstream/integrations/cdi/types/StorageManagerConverterXMLTest.java
@@ -37,7 +37,7 @@ import one.microstream.storage.types.StorageManager;
 public class StorageManagerConverterXMLTest
 {
 	@Inject
-	@ConfigProperty(name = "microstream.xml")
+	@ConfigProperty(name = "one.microstream.xml")
 	private StorageManager manager;
 	
 	@Test

--- a/integrations/cdi/src/test/resources/META-INF/microprofile-config.properties
+++ b/integrations/cdi/src/test/resources/META-INF/microprofile-config.properties
@@ -1,7 +1,7 @@
 
-microstream.xml=storage.xml
-microstream.ini=storage.ini
-microstream.properties=storage.properties
+one.microstream.xml=storage.xml
+one.microstream.ini=storage.ini
+one.microstream.properties=storage.properties
 #microstream
 storage-directory=target/properties
 channel-count=4


### PR DESCRIPTION
Use "one.microstream." as prefix for MicroProfile Configuration keys used by CDI extension.