### PR TITLE
Extract super-interface for type handler registration in foundations

### DIFF
--- a/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/types/BinaryHandlersAndroid.java
+++ b/persistence/binary-android/src/main/java/one/microstream/persistence/binary/android/types/BinaryHandlersAndroid.java
@@ -34,7 +34,7 @@ import one.microstream.persistence.binary.android.java.time.BinaryHandlerYear;
 import one.microstream.persistence.binary.android.java.time.BinaryHandlerYearMonth;
 import one.microstream.persistence.binary.android.java.time.BinaryHandlerZonedDateTime;
 import one.microstream.persistence.binary.types.Binary;
-import one.microstream.persistence.types.PersistenceFoundation;
+import one.microstream.persistence.types.PersistenceTypeHandlerRegistration;
 
 /**
  * Registeres special type handlers written for Android.
@@ -44,9 +44,9 @@ import one.microstream.persistence.types.PersistenceFoundation;
  */
 public final class BinaryHandlersAndroid
 {
-	public static <F extends PersistenceFoundation<Binary, ?>> F registerAndroidTypeHandlers(final F foundation)
+	public static <F extends PersistenceTypeHandlerRegistration.Executor<Binary>> F registerAndroidTypeHandlers(final F executor)
 	{
-		foundation.executeTypeHandlerRegistration((r, c) ->
+		executor.executeTypeHandlerRegistration((r, c) ->
 			r.registerTypeHandlers(X.List(
 				BinaryHandlerDuration.New(),
 				BinaryHandlerInstant.New(),
@@ -63,6 +63,23 @@ public final class BinaryHandlersAndroid
 			))
 		);
 		
-		return foundation;
+		return executor;
 	}
+	
+	
+	///////////////////////////////////////////////////////////////////////////
+	// constructors //
+	/////////////////
+	
+	/**
+	 * Dummy constructor to prevent instantiation of this static-only utility class.
+	 *
+	 * @throws UnsupportedOperationException when called
+	 */
+	protected BinaryHandlersAndroid()
+	{
+		// static only
+		throw new UnsupportedOperationException();
+	}
+	
 }

--- a/persistence/binary-jdk17/src/main/java/one/microstream/persistence/binary/jdk17/types/BinaryHandlersJDK17.java
+++ b/persistence/binary-jdk17/src/main/java/one/microstream/persistence/binary/jdk17/types/BinaryHandlersJDK17.java
@@ -24,19 +24,36 @@ import one.microstream.X;
 import one.microstream.persistence.binary.jdk17.java.util.BinaryHandlerImmutableCollectionsList12;
 import one.microstream.persistence.binary.jdk17.java.util.BinaryHandlerImmutableCollectionsSet12;
 import one.microstream.persistence.binary.types.Binary;
-import one.microstream.persistence.types.PersistenceFoundation;
+import one.microstream.persistence.types.PersistenceTypeHandlerRegistration;
 
 public final class BinaryHandlersJDK17
 {
-	public static <F extends PersistenceFoundation<Binary, ?>> F registerJDK17TypeHandlers(final F foundation)
+	public static <F extends PersistenceTypeHandlerRegistration.Executor<Binary>> F registerJDK17TypeHandlers(final F executor)
 	{
-		foundation.executeTypeHandlerRegistration((r, c) ->
+		executor.executeTypeHandlerRegistration((r, c) ->
 			r.registerTypeHandlers(X.List(
 				BinaryHandlerImmutableCollectionsSet12.New(),
 				BinaryHandlerImmutableCollectionsList12.New()
 			))
 		);
 
-		return foundation;
+		return executor;
 	}
+	
+	
+	///////////////////////////////////////////////////////////////////////////
+	// constructors //
+	/////////////////
+	
+	/**
+	 * Dummy constructor to prevent instantiation of this static-only utility class.
+	 *
+	 * @throws UnsupportedOperationException when called
+	 */
+	protected BinaryHandlersJDK17()
+	{
+		// static only
+		throw new UnsupportedOperationException();
+	}
+	
 }

--- a/persistence/binary-jdk8/src/main/java/one/microstream/persistence/binary/jdk8/types/BinaryHandlersJDK8.java
+++ b/persistence/binary-jdk8/src/main/java/one/microstream/persistence/binary/jdk8/types/BinaryHandlersJDK8.java
@@ -31,13 +31,13 @@ import one.microstream.persistence.binary.jdk8.java.util.BinaryHandlerProperties
 import one.microstream.persistence.binary.jdk8.java.util.BinaryHandlerStack;
 import one.microstream.persistence.binary.jdk8.java.util.BinaryHandlerVector;
 import one.microstream.persistence.binary.types.Binary;
-import one.microstream.persistence.types.PersistenceFoundation;
+import one.microstream.persistence.types.PersistenceTypeHandlerRegistration;
 
 public final class BinaryHandlersJDK8
 {
-	public static <F extends PersistenceFoundation<Binary, ?>> F registerJDK8TypeHandlers(final F foundation)
+	public static <F extends PersistenceTypeHandlerRegistration.Executor<Binary>> F registerJDK8TypeHandlers(final F executor)
 	{
-		foundation.executeTypeHandlerRegistration((r, c) ->
+		executor.executeTypeHandlerRegistration((r, c) ->
 			r.registerTypeHandlers(X.List(
 				// JDK 1.0 collections
 				BinaryHandlerVector.New(c)      ,
@@ -56,6 +56,23 @@ public final class BinaryHandlersJDK8
 			))
 		);
 		
-		return foundation;
+		return executor;
 	}
+	
+	
+	///////////////////////////////////////////////////////////////////////////
+	// constructors //
+	/////////////////
+	
+	/**
+	 * Dummy constructor to prevent instantiation of this static-only utility class.
+	 *
+	 * @throws UnsupportedOperationException when called
+	 */
+	protected BinaryHandlersJDK8()
+	{
+		// static only
+		throw new UnsupportedOperationException();
+	}
+	
 }

--- a/persistence/binary/src/main/java/one/microstream/persistence/binary/util/SerializerFoundation.java
+++ b/persistence/binary/src/main/java/one/microstream/persistence/binary/util/SerializerFoundation.java
@@ -123,7 +123,10 @@ import one.microstream.util.InstanceDispatcher;
  * @param <F> the foundation type
  */
 public interface SerializerFoundation<F extends SerializerFoundation<?>>
-extends ByteOrderTargeting.Mutable<F>, PersistenceDataTypeHolder<Binary>, InstanceDispatcher
+extends ByteOrderTargeting.Mutable<F>,
+        PersistenceDataTypeHolder<Binary>,
+        PersistenceTypeHandlerRegistration.Executor<Binary>,
+        InstanceDispatcher
 {
 	public XMap<Class<?>, PersistenceTypeHandler<Binary, ?>> customTypeHandlers();
 
@@ -375,18 +378,7 @@ extends ByteOrderTargeting.Mutable<F>, PersistenceDataTypeHolder<Binary>, Instan
 	public F setInstantiator(PersistenceInstantiator<Binary> instantiator);
 	
 	public F setInstantiatorProvider(PersistenceTypeInstantiatorProvider<Binary> instantiatorProvider);
-	
-	/**
-	 * Executes the passed {@link PersistenceTypeHandlerRegistration} logic while supplying this instance's
-	 * {@link PersistenceCustomTypeHandlerRegistry} and {@link PersistenceSizedArrayLengthController} instances.
-	 * The passed instance itself will not be referenced after the method exits.
-	 * 
-	 * @param typeHandlerRegistration the {@link PersistenceTypeHandlerRegistration} to be executed.
-	 * 
-	 * @return {@literal this} to allow method chaining.
-	 */
-	public F executeTypeHandlerRegistration(PersistenceTypeHandlerRegistration<Binary> typeHandlerRegistration);
-	
+
 	public XTable<String, BinaryValueSetter> getCustomTranslatorLookup();
 	
 	public XEnum<BinaryValueTranslatorKeyBuilder> getTranslatorKeyBuilders();
@@ -2234,14 +2226,12 @@ extends ByteOrderTargeting.Mutable<F>, PersistenceDataTypeHolder<Binary>, Instan
 		////////////
 
 		@Override
-		public F executeTypeHandlerRegistration(final PersistenceTypeHandlerRegistration<Binary> typeHandlerRegistration)
+		public void executeTypeHandlerRegistration(final PersistenceTypeHandlerRegistration<Binary> typeHandlerRegistration)
 		{
 			typeHandlerRegistration.registerTypeHandlers(
 				this.getCustomTypeHandlerRegistry(),
 				this.getSizedArrayLengthController()
 			);
-			
-			return this.$();
 		}
 		
 		

--- a/persistence/persistence/src/main/java/one/microstream/persistence/types/PersistenceFoundation.java
+++ b/persistence/persistence/src/main/java/one/microstream/persistence/types/PersistenceFoundation.java
@@ -56,7 +56,11 @@ import one.microstream.util.InstanceDispatcher;
  * @param <F> the foundation type
  */
 public interface PersistenceFoundation<D, F extends PersistenceFoundation<D, ?>>
-extends Cloneable<PersistenceFoundation<D, F>>, ByteOrderTargeting.Mutable<F>, PersistenceDataTypeHolder<D>, InstanceDispatcher
+extends Cloneable<PersistenceFoundation<D, F>>,
+        ByteOrderTargeting.Mutable<F>,
+        PersistenceDataTypeHolder<D>,
+        PersistenceTypeHandlerRegistration.Executor<D>,
+        InstanceDispatcher
 {
 	// the pseudo-self-type F is to avoid having to override every setter in every sub class (it was really tedious)
 	
@@ -398,17 +402,6 @@ extends Cloneable<PersistenceFoundation<D, F>>, ByteOrderTargeting.Mutable<F>, P
 	public F setInstantiator(PersistenceInstantiator<D> instantiator);
 	
 	public F setInstantiatorProvider(PersistenceTypeInstantiatorProvider<D> instantiatorProvider);
-	
-	/**
-	 * Executes the passed {@link PersistenceTypeHandlerRegistration} logic while supplying this instance's
-	 * {@link PersistenceCustomTypeHandlerRegistry} and {@link PersistenceSizedArrayLengthController} instances.
-	 * The passed instance itself will not be referenced after the method exits.
-	 * 
-	 * @param typeHandlerRegistration the {@link PersistenceTypeHandlerRegistration} to be executed.
-	 * 
-	 * @return {@literal this} to allow method chaining.
-	 */
-	public F executeTypeHandlerRegistration(PersistenceTypeHandlerRegistration<D> typeHandlerRegistration);
 		
 	public F setCustomTypeHandlerRegistryEnsurer(
 		PersistenceCustomTypeHandlerRegistryEnsurer<D> customTypeHandlerRegistryEnsurer
@@ -2516,14 +2509,12 @@ extends Cloneable<PersistenceFoundation<D, F>>, ByteOrderTargeting.Mutable<F>, P
 		////////////
 
 		@Override
-		public F executeTypeHandlerRegistration(final PersistenceTypeHandlerRegistration<D> typeHandlerRegistration)
+		public void executeTypeHandlerRegistration(final PersistenceTypeHandlerRegistration<D> typeHandlerRegistration)
 		{
 			typeHandlerRegistration.registerTypeHandlers(
 				this.getCustomTypeHandlerRegistry(),
 				this.getSizedArrayLengthController()
 			);
-			
-			return this.$();
 		}
 		
 		@Override

--- a/persistence/persistence/src/main/java/one/microstream/persistence/types/PersistenceTypeHandlerRegistration.java
+++ b/persistence/persistence/src/main/java/one/microstream/persistence/types/PersistenceTypeHandlerRegistration.java
@@ -27,4 +27,20 @@ public interface PersistenceTypeHandlerRegistration<D>
 		PersistenceCustomTypeHandlerRegistry<D> customTypeHandlerRegistry ,
 		PersistenceSizedArrayLengthController   sizedArrayLengthController
 	);
+	
+	
+	@FunctionalInterface
+	public static interface Executor<D>
+	{
+		/**
+		 * Executes the passed {@link PersistenceTypeHandlerRegistration} logic while supplying this instance's
+		 * {@link PersistenceCustomTypeHandlerRegistry} and {@link PersistenceSizedArrayLengthController} instances.
+		 * The passed instance itself will not be referenced after the method exits.
+		 * 
+		 * @param typeHandlerRegistration the {@link PersistenceTypeHandlerRegistration} to be executed.
+		 */
+		public void executeTypeHandlerRegistration(PersistenceTypeHandlerRegistration<D> typeHandlerRegistration);
+		
+	}
+	
 }

--- a/storage/embedded/src/main/java/one/microstream/storage/embedded/types/EmbeddedStorageFoundation.java
+++ b/storage/embedded/src/main/java/one/microstream/storage/embedded/types/EmbeddedStorageFoundation.java
@@ -28,7 +28,6 @@ import org.slf4j.Logger;
 import one.microstream.exceptions.MissingFoundationPartException;
 import one.microstream.persistence.binary.types.Binary;
 import one.microstream.persistence.types.Persistence;
-import one.microstream.persistence.types.PersistenceFoundation;
 import one.microstream.persistence.types.PersistenceObjectIdProvider;
 import one.microstream.persistence.types.PersistenceRefactoringMappingProvider;
 import one.microstream.persistence.types.PersistenceRootResolverProvider;
@@ -77,7 +76,8 @@ import one.microstream.util.logging.Logging;
  *
  * @param <F> the "self-type" of the  {@link EmbeddedStorageManager} implementation.
  */
-public interface EmbeddedStorageFoundation<F extends EmbeddedStorageFoundation<?>> extends StorageFoundation<F>
+public interface EmbeddedStorageFoundation<F extends EmbeddedStorageFoundation<?>>
+extends StorageFoundation<F>, PersistenceTypeHandlerRegistration.Executor<Binary>
 {
 	public static interface Creator
 	{
@@ -363,17 +363,6 @@ public interface EmbeddedStorageFoundation<F extends EmbeddedStorageFoundation<?
 	 * @see EmbeddedStorageConnectionFoundation#setRefactoringMappingProvider(PersistenceRefactoringMappingProvider)
 	 */
 	public F setRefactoringMappingProvider(PersistenceRefactoringMappingProvider refactoringMappingProvider);
-
-	/**
-	 * Convenience method for {@code this.getConnectionFoundation().executeTypeHandlerRegistration(typeHandlerRegistration)}.
-	 * <p>
-	 * See {@link PersistenceFoundation#executeTypeHandlerRegistration(PersistenceTypeHandlerRegistration)} for details.
-	 *
-	 * @param typeHandlerRegistration the {@link PersistenceTypeHandlerRegistration} to be executed.
-	 *
-	 * @return {@literal this} to allow method chaining.
-	 */
-	public F executeTypeHandlerRegistration(PersistenceTypeHandlerRegistration<Binary> typeHandlerRegistration);
 
 	public F registerTypeHandler(PersistenceTypeHandler<Binary, ?> typeHandler);
 
@@ -741,10 +730,9 @@ public interface EmbeddedStorageFoundation<F extends EmbeddedStorageFoundation<?
 		}
 
 		@Override
-		public F executeTypeHandlerRegistration(final PersistenceTypeHandlerRegistration<Binary> typeHandlerRegistration)
+		public void executeTypeHandlerRegistration(final PersistenceTypeHandlerRegistration<Binary> typeHandlerRegistration)
 		{
 			this.getConnectionFoundation().executeTypeHandlerRegistration(typeHandlerRegistration);
-			return this.$();
 		}
 
 		@Override


### PR DESCRIPTION
In order to use BinaryHandlersJDK8/17/Android conveniently in the SerializerFoundation as well, a super-interface is introduced and used in the foundation types.