### PR TITLE
SqlPath separator confilicts 

### DIFF
--- a/afs/sql/src/main/java/one/microstream/afs/sql/types/SqlConnector.java
+++ b/afs/sql/src/main/java/one/microstream/afs/sql/types/SqlConnector.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.LongFunction;
 
+import one.microstream.chars.XChars;
 import one.microstream.io.ByteBufferInputStream;
 import one.microstream.io.LimitedInputStream;
 import one.microstream.reference.Reference;
@@ -180,7 +181,7 @@ public interface SqlConnector
 		)
 		throws SQLException
 		{
-			final String       directoryPrefix = directory.fullQualifiedName() + SqlPath.DIRECTORY_TABLE_NAME_SEPARATOR;
+			final String       directoryPrefix = directory.fullQualifiedName() + SqlPath.getSeparatorString();
 			final List<String> directories     = new ArrayList<>();
 
 			if(this.useCache)
@@ -203,11 +204,16 @@ public interface SqlConnector
 					)
 				);
 			}
-
+		
 			directories.stream()
 				.filter(name -> name.startsWith(directoryPrefix)
 					&& name.length() > directoryPrefix.length()
-					&& name.indexOf(SqlPath.DIRECTORY_TABLE_NAME_SEPARATOR, directoryPrefix.length()) == -1
+				)
+				.map( name ->
+					name.replace(directoryPrefix, "")
+				)
+				.map( name ->
+						XChars.splitSimple(name, SqlPath.getSeparatorString())[0]
 				)
 				.forEach(visitor::visitItem);
 		}

--- a/afs/sql/src/main/java/one/microstream/afs/sql/types/SqlFileSystem.java
+++ b/afs/sql/src/main/java/one/microstream/afs/sql/types/SqlFileSystem.java
@@ -184,7 +184,7 @@ public interface SqlFileSystem extends AFileSystem, AResolver<SqlPath, SqlPath>
 		{
 			return XChars.assembleSeparated(
 				vs,
-				SqlPath.DIRECTORY_TABLE_NAME_SEPARATOR_CHAR,
+				SqlPath.getSeparatorChar(),
 				item.toPath()
 			);
 		}

--- a/afs/sql/src/main/java/one/microstream/afs/sql/types/SqlPath.java
+++ b/afs/sql/src/main/java/one/microstream/afs/sql/types/SqlPath.java
@@ -30,9 +30,6 @@ import one.microstream.collections.XArrays;
 
 public interface SqlPath
 {
-	final static String DIRECTORY_TABLE_NAME_SEPARATOR      = "_";
-	final static char   DIRECTORY_TABLE_NAME_SEPARATOR_CHAR = '_';
-
 	public String[] pathElements();
 
 	public String identifier();
@@ -46,7 +43,7 @@ public interface SqlPath
 		final String fullQualifiedPath
 	)
 	{
-		return XChars.splitSimple(fullQualifiedPath, DIRECTORY_TABLE_NAME_SEPARATOR);
+		return XChars.splitSimple(fullQualifiedPath, getSeparatorString());
 	}
 
 	public static SqlPath New(
@@ -59,6 +56,44 @@ public interface SqlPath
 	}
 
 
+	public static SqlPathSeparatorProvider set(final SqlPathSeparatorProvider sqlPathSeparatorProvider)
+	{
+		return Static.set(sqlPathSeparatorProvider);
+	}
+	
+	public static SqlPathSeparatorProvider get()
+	{
+		return Static.get();
+	}
+	
+	static String getSeparatorString()
+	{
+		return Static.get().getSqlPathSeparator();
+	}
+	
+	static char getSeparatorChar()
+	{
+		return Static.get().getSqlPathSeparatorChar();
+	}
+	
+	
+	public final class Static
+	{
+		static SqlPathSeparatorProvider pathSeparatorProvider = SqlPathSeparatorProvider.New();
+		
+		static synchronized SqlPathSeparatorProvider set(final SqlPathSeparatorProvider sqlPathSeparatorProvider)
+		{
+			pathSeparatorProvider = sqlPathSeparatorProvider;
+			return pathSeparatorProvider;
+		}
+
+		static synchronized SqlPathSeparatorProvider get()
+		{
+			return pathSeparatorProvider;
+		}
+		
+	}
+	
 	public final static class Default implements SqlPath
 	{
 		private final String[] pathElements     ;
@@ -91,7 +126,7 @@ public interface SqlPath
 			{
 				this.fullQualifiedName = Arrays
 					.stream(this.pathElements)
-					.collect(joining(DIRECTORY_TABLE_NAME_SEPARATOR))
+					.collect(joining(SqlPath.getSeparatorString()))
 				;
 			}
 

--- a/afs/sql/src/main/java/one/microstream/afs/sql/types/SqlPathSeparatorProvider.java
+++ b/afs/sql/src/main/java/one/microstream/afs/sql/types/SqlPathSeparatorProvider.java
@@ -1,0 +1,105 @@
+package one.microstream.afs.sql.types;
+
+/*-
+ * #%L
+ * MicroStream Abstract File System - SQL
+ * %%
+ * Copyright (C) 2019 - 2022 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is
+ * available at https://www.gnu.org/software/classpath/license.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * #L%
+ */
+
+/**
+ * Configure the separator character used by the microstream SQL AFS implementation.
+ * Classes that implement this interface must provide the character as sting and as char.
+ * The supplied character is used to separate path components and file names when mapping
+ * directory structures to SQL-Table names.
+ * Therefore the supplied character must be allowed to be part of table names of the used
+ * SQL database the AFS is working with.
+ * <p>
+ * The configuration has to be done before any SQLFileSystem instance is created!
+ * <p>
+ * The configuration is done static via the {@link SqlPath} class.
+ * <p>
+ * E.g. to configure "_" as separator:
+ * <blockquote><pre>
+ * SqlPath.set(SqlPathSeparatorProvider.New("_", '_'));
+ * </pre></blockquote><p>
+ */
+public interface SqlPathSeparatorProvider
+{
+	final static String DIRECTORY_TABLE_NAME_SEPARATOR_DEFAULT      = "$";
+	final static char   DIRECTORY_TABLE_NAME_SEPARATOR_DEFAULT_CHAR = '$';
+	
+	public char getSqlPathSeparatorChar();
+	
+	public String getSqlPathSeparator();
+	
+	/**
+	 * Create a Default instance that provides the default
+	 * separator '$'.
+	 * 
+	 * @return an instance of SqlPathSeparatorProvider.Default.
+	 */
+	public static Default New()
+	{
+		return new Default(
+			DIRECTORY_TABLE_NAME_SEPARATOR_DEFAULT,
+			DIRECTORY_TABLE_NAME_SEPARATOR_DEFAULT_CHAR
+		);
+	}
+	
+	/**
+	 * Create a Default instance that provides the configured
+	 * separator.
+	 * The both parameters must configure the same character as String and as char.
+	 * 
+	 * @param pathSeparator the separator as String
+	 * @param pathSeparatorChar the separator as char
+	 * @return an instance of SqlPathSeparatorProvider.Default.
+	 */
+	public static Default New(final String pathSeparator, final char pathSeparatorChar)
+	{
+		return new Default(
+			pathSeparator,
+			pathSeparatorChar
+		);
+	}
+		
+	public static class Default implements SqlPathSeparatorProvider
+	{
+		String pathSeparator;
+		char   pathSeparatorChar;
+		
+		Default(final String pathSeparator, final char pathSeparatorChar)
+		{
+			this.pathSeparator     = pathSeparator;
+			this.pathSeparatorChar = pathSeparatorChar;
+		}
+				
+		@Override
+		public char getSqlPathSeparatorChar()
+		{
+			return this.pathSeparatorChar;
+		}
+
+		@Override
+		public String getSqlPathSeparator()
+		{
+			return this.pathSeparator;
+		}
+
+		
+	}
+}


### PR DESCRIPTION
closes: https://github.com/microstream-one/microstream-private/issues/634

Issue:
The SQLConnector uses the ( _ ) underscore as directory name separator. This causes a conflict with the storage default channel directory name “channel_”.
As consequence default table names like storage_channel_0 are not correctly resolved to the expected path storage/channel_0 e.g., when inventorying directories.

Solution:
The solution adds the posibility to configure the separator and changes the default one form "_" to "$".

THIS IS A BREAKING CHANGE!

To use sql storage targets created before the exising table names have to be renamed manually.