### PR TITLE
use read/write methods with timeout

### DIFF
--- a/communication/communication/src/main/java/one/microstream/communication/types/ComConnection.java
+++ b/communication/communication/src/main/java/one/microstream/communication/types/ComConnection.java
@@ -132,13 +132,13 @@ public interface ComConnection
 		@Override
 		public void readUnsecure(final ByteBuffer buffer)
 		{
-			XSockets.readCompletely(this.channel, buffer);
+			this.readCompletely(buffer);
 		}
 		
 		@Override
 		public void writeUnsecured(final ByteBuffer buffer)
 		{
-			XSockets.writeCompletely(this.channel, buffer);
+			this.writeCompletely(buffer);
 		}
 
 		@Override


### PR DESCRIPTION
The non ecrpyted ComConnection Host implementation may be block forever if a client does not send anthing after connecting to the host socket.
To solve this the host now uses a timeout when waiting for initial client data.