### PR TITLE
add dependency for java.xml.bind

### DIFF
--- a/storage/rest/client-jersey/pom.xml
+++ b/storage/rest/client-jersey/pom.xml
@@ -21,6 +21,7 @@
 	<properties>
 		<jersey.version>2.33</jersey.version>
 		<gson.version>2.8.9</gson.version>
+		<jaxb.version>2.3.1</jaxb.version>
 	</properties>
 
 	<dependencies>
@@ -43,6 +44,11 @@
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
 			<version>${gson.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>${jaxb.version}</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Add dependency to eliminate problem with javac compiler. 
module java.xml.bin not found. 

This module has been removed from java11+ and must be added as a dependency. We are not using it, I just add an API.
https://stackoverflow.com/questions/52502189/java-11-package-javax-xml-bind-does-not-exist