### PR TITLE
Define service providers in module info

### DIFF
--- a/afs/sql/src/main/java/module-info.java
+++ b/afs/sql/src/main/java/module-info.java
@@ -21,6 +21,12 @@ module microstream.afs.sql
 {
 	exports one.microstream.afs.sql.types;
 	
+	provides one.microstream.configuration.types.ConfigurationBasedCreator
+	    with one.microstream.afs.sql.types.SqlFileSystemCreatorMariaDb,
+	         one.microstream.afs.sql.types.SqlFileSystemCreatorPostgres,
+	         one.microstream.afs.sql.types.SqlFileSystemCreatorSqlite
+	;
+	
 	requires transitive microstream.afs;
 	requires transitive microstream.configuration;
 	requires transitive java.sql;

--- a/base/src/main/java/module-info.java
+++ b/base/src/main/java/module-info.java
@@ -56,6 +56,11 @@ module microstream.base
 	exports one.microstream.math;
 	exports one.microstream.util.cql;
 	exports one.microstream.time;
+	
+	provides javax.annotation.processing.Processor
+	    with one.microstream.entity.codegen.EntityProcessor,
+	         one.microstream.wrapping.codegen.WrapperProcessor
+	;
 
 	requires java.compiler;
 	requires transitive java.management;

--- a/cache/cache/src/main/java/module-info.java
+++ b/cache/cache/src/main/java/module-info.java
@@ -22,6 +22,10 @@ module microstream.cache
 	exports one.microstream.cache.types;
 	exports one.microstream.cache.exceptions;
 	
+	provides javax.cache.spi.CachingProvider
+	    with one.microstream.cache.types.CachingProvider
+	;
+	
 	requires transitive microstream.persistence.binary;
 	requires transitive microstream.storage.embedded.configuration;
 	requires transitive cache.api;

--- a/storage/rest/client-app/src/main/java/module-info.java
+++ b/storage/rest/client-app/src/main/java/module-info.java
@@ -22,6 +22,10 @@ module microstream.storage.restclient.app
 	exports one.microstream.storage.restclient.app.types;
 	exports one.microstream.storage.restclient.app.ui;
 	
+	provides com.vaadin.flow.server.VaadinServiceInitListener
+	    with one.microstream.storage.restclient.app.types.ApplicationServiceInitListener
+	;
+	
 	requires flow.data;
 	requires flow.html.components;
 	requires flow.server;

--- a/storage/rest/service-sparkjava/src/main/java/module-info.java
+++ b/storage/rest/service-sparkjava/src/main/java/module-info.java
@@ -22,6 +22,13 @@ module microstream.storage.restservice.sparkjava
 	exports one.microstream.storage.restservice.sparkjava.exceptions;
 	exports one.microstream.storage.restservice.sparkjava.types;
 	
+	provides one.microstream.storage.restadapter.types.StorageViewDataConverter
+	    with one.microstream.storage.restservice.sparkjava.types.StorageViewDataConverterJson
+	;
+	provides one.microstream.storage.restservice.types.StorageRestServiceProvider
+	    with one.microstream.storage.restservice.sparkjava.types.StorageRestServiceProviderSparkJava
+	;
+	
 	requires transitive microstream.storage.restservice;
 	requires transitive com.google.gson;
 	requires transitive spark.core;


### PR DESCRIPTION
The service providers which are registered in META-INF/services must be defined in the module-info as well.