### PR TITLE
Store reference inside Lazy when Lazy is marked (CDI integration)

### DIFF
--- a/docs/modules/misc/pages/integrations/cdi.adoc
+++ b/docs/modules/misc/pages/integrations/cdi.adoc
@@ -125,6 +125,8 @@ The `@Store` CDI interceptor on the calling method makes sure that all instances
 
 By default, the CDI interceptor will use an asynchronous way of storing the instances so that the response can be sent faster since it doesn't need to wait before data is stored.
 
+If you _mark_ a `Lazy` instance, the reference that is _inside_ the Lazy reference is also stored to the storage target. This is to make sure that an item that is added to a List within the Lazy is also stored. And you don't need to mark the Lazy and the reference _inside_ it separately.
+
 Also, if you mark any `Lazy` instance of MicroStream, it will be cleared automatically when it is stored.
 
 You can change this behaviour by specifying different member values.

--- a/integrations/cdi/src/main/java/one/microstream/integrations/cdi/types/extension/InstanceStorer.java
+++ b/integrations/cdi/src/main/java/one/microstream/integrations/cdi/types/extension/InstanceStorer.java
@@ -157,7 +157,11 @@ public class InstanceStorer
     {
         if (dirtyInstance instanceof Lazy) {
             // When a Lazy is marked, the developer probably wants to store the referenced instance in the Lazy.
-            this.manager.store(((Lazy<?>) dirtyInstance).get());
+            Object instance = ((Lazy<?>) dirtyInstance).peek();
+            if (instance != null)
+            {
+                this.manager.store(instance);
+            }
         }
         this.manager.store(dirtyInstance);
         if (clearLazy && dirtyInstance instanceof Lazy)

--- a/integrations/cdi/src/main/java/one/microstream/integrations/cdi/types/extension/InstanceStorer.java
+++ b/integrations/cdi/src/main/java/one/microstream/integrations/cdi/types/extension/InstanceStorer.java
@@ -155,6 +155,10 @@ public class InstanceStorer
 
     public void storeChanged(final Object dirtyInstance, final boolean clearLazy)
     {
+        if (dirtyInstance instanceof Lazy) {
+            // When a Lazy is marked, the developer probably wants to store the referenced instance in the Lazy.
+            this.manager.store(((Lazy<?>) dirtyInstance).get());
+        }
         this.manager.store(dirtyInstance);
         if (clearLazy && dirtyInstance instanceof Lazy)
         {

--- a/integrations/cdi/src/test/java/one/microstream/integrations/cdi/types/interceptor/StoreInterceptorTest.java
+++ b/integrations/cdi/src/test/java/one/microstream/integrations/cdi/types/interceptor/StoreInterceptorTest.java
@@ -176,8 +176,12 @@ class StoreInterceptorTest
 		// Some logic that needs to be done to handle Lazy properly. (so that we can check .isLoaded)
 		Mockito.doAnswer((Answer<Void>) invocationOnMock ->
 				{
-					Lazy.Default lazy = (Lazy.Default) invocationOnMock.getArguments()[0];
-					lazy.$link(1L, objectSwizzlingMock);
+					Object argument = invocationOnMock.getArguments()[0];
+					if (argument instanceof Lazy)
+					{
+						Lazy.Default lazy = (Lazy.Default) argument;
+						lazy.$link(1L, objectSwizzlingMock);
+					}
 					return null;
 				})
 				.when(storageManagerMock)
@@ -294,8 +298,12 @@ class StoreInterceptorTest
 		// Some logic that needs to be done to handle Lazy properly. (so that we can check .isLoaded)
 		Mockito.doAnswer((Answer<Void>) invocationOnMock ->
 				{
-					Lazy.Default lazy = (Lazy.Default) invocationOnMock.getArguments()[0];
-					lazy.$link(1L, objectSwizzlingMock);
+					Object argument = invocationOnMock.getArguments()[0];
+					if (argument instanceof Lazy)
+					{
+						Lazy.Default lazy = (Lazy.Default) argument;
+						lazy.$link(1L, objectSwizzlingMock);
+					}
 					return null;
 				})
 				.when(storageManagerMock)


### PR DESCRIPTION
When a `Lazy` reference is marked by developer, the instance _inside_ the `Lazy` is also stored as that is probably the intention (and makes working and clearing with Lazy references easier).