### PR TITLE
CompilerId as Project parameter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
+		<maven.compiler.compilerId>eclipse</maven.compiler.compilerId>
 		<org.owasp.depencency.check.version>6.1.6</org.owasp.depencency.check.version>
 		<org.eclipse.jdt.ecj.version>3.29.0</org.eclipse.jdt.ecj.version>
 		<license.inceptionYear>2019</license.inceptionYear>
@@ -137,9 +138,6 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.10.1</version>
-					<configuration>
-						<compilerId>eclipse</compilerId>
-					</configuration>
 					<executions>
 						<execution>
 							<id>default-compile</id>


### PR DESCRIPTION
A small change that gives the definition of the used java compiler as a parameter. With this change, I can create a job that will build this project with a different compiler than the default compiler. 