### PR TITLE
Removed logging of lazy subject

### DIFF
--- a/base/src/main/java/one/microstream/reference/Lazy.java
+++ b/base/src/main/java/one/microstream/reference/Lazy.java
@@ -424,22 +424,20 @@ public interface Lazy<T> extends Referencing<T>
 			this.subject = (T)this.loader.getObject(this.objectId);
 			
 			logger.debug(
-				"Lazy loaded {}: {}({})",
+				"Lazy loaded {}: {}",
 				this.objectId,
-				LazyArg(() -> systemString(this.subject)),
-				this.subject
+				LazyArg(() -> systemString(this.subject))
 			);
 		}
 
 		final synchronized boolean clearIfTimedout(final long millisecondThreshold)
 		{
 			logger.trace(
-				"Checking lazy {} ({} vs {}): {}({})",
+				"Checking lazy {} ({} vs {}): {}",
 				this.objectId,
 				this.lastTouched,
 				millisecondThreshold,
-				LazyArg(() -> systemString(this.subject)),
-				this.subject
+				LazyArg(() -> systemString(this.subject))
 			);
 
 			// time check implicitely covers already cleared reference. May of course not clear unstored references.
@@ -449,10 +447,9 @@ public interface Lazy<T> extends Referencing<T>
 			}
 
 			logger.debug(
-				"Timeout-clearing lazy {}: {}({})",
+				"Timeout-clearing lazy {}: {}",
 				this.objectId,
-				LazyArg(() -> systemString(this.subject)),
-				this.subject
+				LazyArg(() -> systemString(this.subject))
 			);
 			this.internalClear();
 			return true;


### PR DESCRIPTION
Logging the lazy loaded data can create very large log entries e.g. if it is a lazy loaded list and may cause user data to be logged.
Therefore the logging of the lazy loaded content is removed.