### PR TITLE
GC Live Object Check

### DIFF
--- a/base/src/main/java/one/microstream/collections/Set_long.java
+++ b/base/src/main/java/one/microstream/collections/Set_long.java
@@ -1,5 +1,25 @@
 package one.microstream.collections;
 
+/*-
+ * #%L
+ * MicroStream Base
+ * %%
+ * Copyright (C) 2019 - 2022 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is
+ * available at https://www.gnu.org/software/classpath/license.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * #L%
+ */
+
 import one.microstream.collections.interfaces.OptimizableCollection;
 import one.microstream.functional._longIterable;
 import one.microstream.functional._longPredicate;
@@ -7,11 +27,6 @@ import one.microstream.functional._longProcedure;
 import one.microstream.math.XMath;
 import one.microstream.typing.Composition;
 
-/**
- *
- * 
- *
- */
 public interface Set_long extends OptimizableCollection, Composition, _longIterable
 {
 	public boolean add(long element);

--- a/base/src/main/java/one/microstream/collections/Set_long.java
+++ b/base/src/main/java/one/microstream/collections/Set_long.java
@@ -1,0 +1,310 @@
+package one.microstream.collections;
+
+import one.microstream.collections.interfaces.OptimizableCollection;
+import one.microstream.functional._longIterable;
+import one.microstream.functional._longPredicate;
+import one.microstream.functional._longProcedure;
+import one.microstream.math.XMath;
+import one.microstream.typing.Composition;
+
+/**
+ *
+ * 
+ *
+ */
+public interface Set_long extends OptimizableCollection, Composition, _longIterable
+{
+	public boolean add(long element);
+
+	public boolean contains(long element);
+
+	public void clear();
+
+	public void truncate();
+
+	public Set_long filter(_longPredicate selector);
+
+
+
+	public static Set_long New()
+	{
+		return new Set_long.Default(
+			Default.defaultSlotLength(),
+			Default.defaultChainLength(),
+			Default.defaultChainGrowthFactor()
+		);
+	}
+
+	public static Set_long New(final int slotSize)
+	{
+		return new Set_long.Default(
+			slotSize,
+			Default.defaultChainLength(),
+			Default.defaultChainGrowthFactor()
+		);
+	}
+
+	public static Set_long New(
+		final int   slotSize          ,
+		final int   chainDefaultLength,
+		final float chainGrowthFactor
+	)
+	{
+		return new Set_long.Default(slotSize, chainDefaultLength, chainGrowthFactor);
+	}
+
+
+	public final class Default implements Set_long
+	{
+		///////////////////////////////////////////////////////////////////////////
+		// static methods //
+		///////////////////
+
+		public static final int defaultSlotLength()
+		{
+			return 1;
+		}
+
+		public static final int defaultChainLength()
+		{
+			return 1;
+		}
+
+		public static final float defaultChainGrowthFactor()
+		{
+			// grow by 1 for small chains but grow bigger chains by 10%.
+			return 1.1f;
+		}
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// instance fields //
+		////////////////////
+
+		private long[][] hashSlots;
+		private int      hashRange;
+		private int      size     ;
+
+		private final int chainInitialLength;
+		private final float chainGrowthFactor;
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// constructors //
+		/////////////////
+
+		Default(final int slotSize, final int chainDefaultLength, final float chainGrowthFactor)
+		{
+			super();
+			this.hashSlots = new long[(this.hashRange = XMath.pow2BoundCapped(slotSize) - 1) + 1][];
+			this.chainInitialLength = XMath.positive(chainDefaultLength);
+			this.chainGrowthFactor  = XMath.positive(chainGrowthFactor);
+		}
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// override methods //
+		//////////////////////
+
+		@Override
+		public final long size()
+		{
+			return this.size;
+		}
+
+		@Override
+		public final boolean isEmpty()
+		{
+			return this.size == 0;
+		}
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// declared methods //
+		/////////////////////
+
+		private void rebuild(final int newLength)
+		{
+			if(this.hashSlots.length >= newLength || newLength <= 0)
+			{
+				return;
+			}
+
+			final int      newRange = newLength - 1;
+			final long[][] oldSlots = this.hashSlots;
+			final long[][] newSlots = new long[newLength][];
+
+			// chopped nested for loops into separate methods for JIT'ability.
+			for(int i = 0; i < oldSlots.length; i++)
+			{
+				if(oldSlots[i] == null)
+				{
+					continue;
+				}
+				this.redistributeElements(newSlots, newRange, oldSlots[i]);
+			}
+
+			this.hashSlots = newSlots;
+			this.hashRange = newRange;
+		}
+
+		private void redistributeElements(final long[][] newSlots, final int newRange, final long[] oldChain)
+		{
+			for(final long element : oldChain)
+			{
+				this.addElement(newSlots, hash(element,  newRange), element);
+			}
+		}
+
+		private static int hash(final long element, final int hashRange)
+		{
+			return (int)(element & hashRange);
+		}
+
+		private boolean addElement(final long[][] hashSlots, final int hashIndex, final long element)
+		{
+			final long[] chain;
+			if((chain = hashSlots[hashIndex]) != null)
+			{
+				// normal case: search for an empty slot (0L) in an existing chain
+				for(int n = 0; n < chain.length; n++)
+				{
+					if(chain[n] == 0L)
+					{
+						// found empty slot after the last element
+						chain[n] = element;
+						return true;
+					}
+					if(chain[n] == element)
+					{
+						return false;
+					}
+				}
+
+				// edge case: chain array is full. Enlarge and add element at the first free index.
+				hashSlots[hashIndex] = this.enlargeChain(chain, element);
+				return true;
+			}
+
+			// corner case: no chain at all, yet
+			(hashSlots[hashIndex] = new long[this.chainInitialLength])[0] = element;
+			return true;
+		}
+
+		private long[] enlargeChain(final long[] array, final long newElement)
+		{
+			final int newLength = (int)(array.length * this.chainGrowthFactor);
+
+			final long[] newArray = new long[Math.max(newLength, array.length + 1)];
+			System.arraycopy(array, 0, newArray, 0, array.length);
+			newArray[array.length] = newElement;
+
+			return newArray;
+		}
+
+		@Override
+		public final boolean add(final long element)
+		{
+			if(!this.addElement(this.hashSlots, hash(element, this.hashRange), element))
+			{
+				return false;
+			}
+
+			if(++this.size >= this.hashRange)
+			{
+				this.rebuild((int)(this.hashSlots.length * 2.0f));
+			}
+
+			return true;
+		}
+
+		@Override
+		public final boolean contains(final long element)
+		{
+			if(element != 0L)
+			{
+				for(final long e : this.hashSlots[hash(element, this.hashRange)])
+				{
+					if(e == element)
+					{
+						return true;
+					}
+				}
+			}
+
+			return false;
+		}
+
+		@Override
+		public void iterate(final _longProcedure procedure)
+		{
+			final long[][] hashSlots = this.hashSlots;
+			for(int i = 0; i < hashSlots.length; i++)
+			{
+				if(hashSlots[i] == null)
+				{
+					continue;
+				}
+				for(final long e : hashSlots[i])
+				{
+					if(e == 0L)
+					{
+						break;
+					}
+					procedure.accept(e);
+				}
+			}
+		}
+
+		/**
+		 * Optimizes the internal storage and returns the remaining amount of entries.
+		 * @return the amount of entries after the optimization is been completed.
+		 */
+		@Override
+		public long optimize()
+		{
+			this.rebuild(XMath.pow2BoundCapped(this.size));
+			return this.size;
+		}
+
+		@Override
+		public void clear()
+		{
+			final long[][] slots = this.hashSlots;
+			for(int i = 0, len = slots.length; i < len; i++)
+			{
+				slots[i] = null;
+			}
+			this.size = 0;
+		}
+
+		@Override
+		public void truncate()
+		{
+			this.hashSlots = new long[1][];
+			this.size = 0;
+		}
+
+		@Override
+		public Set_long.Default filter(final _longPredicate selector)
+		{
+			final Set_long.Default result = new Set_long.Default(1, this.chainInitialLength, this.chainGrowthFactor);
+
+			this.iterate(e ->
+			{
+				if(selector.test(e))
+				{
+					result.add(e);
+				}
+			});
+
+			return result;
+		}
+
+	}
+
+}

--- a/persistence/binary/src/main/java/one/microstream/persistence/binary/util/SerializerFoundation.java
+++ b/persistence/binary/src/main/java/one/microstream/persistence/binary/util/SerializerFoundation.java
@@ -2321,6 +2321,7 @@ extends ByteOrderTargeting.Mutable<F>,
 				this.getPersister(),
 				target,
 				source,
+				PersistenceStorer.CreationObserver::noOp, // only relevant for storage
 				this.getBufferSizeProvider(),
 				this.getTargetByteOrder()
 			);

--- a/persistence/persistence/src/main/java/one/microstream/persistence/internal/DefaultObjectRegistry.java
+++ b/persistence/persistence/src/main/java/one/microstream/persistence/internal/DefaultObjectRegistry.java
@@ -24,6 +24,8 @@ import static one.microstream.X.KeyValue;
 
 import java.lang.ref.WeakReference;
 
+import org.slf4j.Logger;
+
 import one.microstream.X;
 import one.microstream.collections.EqHashTable;
 import one.microstream.collections.Set_long;
@@ -43,6 +45,7 @@ import one.microstream.persistence.types.PersistenceAcceptor;
 import one.microstream.persistence.types.PersistenceObjectRegistry;
 import one.microstream.reference.Swizzling;
 import one.microstream.typing.KeyValue;
+import one.microstream.util.logging.Logging;
 
 public final class DefaultObjectRegistry implements PersistenceObjectRegistry
 {
@@ -166,7 +169,8 @@ public final class DefaultObjectRegistry implements PersistenceObjectRegistry
 		;
 	}
 	
-	
+
+	private final static Logger logger = Logging.getLogger(DefaultObjectRegistry.class);
 
 	///////////////////////////////////////////////////////////////////////////
 	// instance fields //
@@ -177,7 +181,7 @@ public final class DefaultObjectRegistry implements PersistenceObjectRegistry
 	 * This does NOT replace locking the whole registry over a not to be "disrupted" process like loading
 	 * (See BinaryLoader#get).
 	 * This is just an internal lock to keep things consistent on a technical level.
-	 * Locking the registry itself continously accross a whole process keeps things consistent
+	 * Locking the registry itself continuously across a whole process keeps things consistent
 	 * on a business-logical level.
 	 * Also note:
 	 * The methode #processLiveObjectIds and #selectLiveObjectIds do not and MAY NOT lock the whole registry
@@ -1097,7 +1101,8 @@ public final class DefaultObjectRegistry implements PersistenceObjectRegistry
 	final boolean synchIsLiveObjectId(final long objectId)
 	{
 		final boolean result = this.synchContainsObjectId(objectId);
-//		XDebug.println("ObjectRegistry checking OID " + objectId + ": " + result);
+		
+		logger.debug("ObjectRegistry checking OID " + objectId + ": " + result);
 
 		return result;
 	}

--- a/persistence/persistence/src/main/java/one/microstream/persistence/internal/DefaultObjectRegistry.java
+++ b/persistence/persistence/src/main/java/one/microstream/persistence/internal/DefaultObjectRegistry.java
@@ -118,7 +118,15 @@ public final class DefaultObjectRegistry implements PersistenceObjectRegistry
 		return System.identityHashCode(object);
 	}
 	
-	
+	private static Entry[] createHashTable(final int hashLength)
+	{
+		return new Entry[hashLength];
+	}
+
+	private static int calculateRequiredHashLength(final long minimumCapacity, final float hashDensity)
+	{
+		return XHashing.padHashLength((long)(minimumCapacity / hashDensity));
+	}
 	
 	///////////////////////////////////////////////////////////////////////////
 	// static constructors //
@@ -150,11 +158,11 @@ public final class DefaultObjectRegistry implements PersistenceObjectRegistry
 	)
 	{
 		return new DefaultObjectRegistry()
-			.internalSetConfiguration(
+			.synchSetConfiguration(
 				validateHashDensity(hashDensity),
 				validateCapacity(minimumCapacity)
 			)
-			.internalReset()
+			.synchReset()
 		;
 	}
 	
@@ -163,6 +171,20 @@ public final class DefaultObjectRegistry implements PersistenceObjectRegistry
 	///////////////////////////////////////////////////////////////////////////
 	// instance fields //
 	////////////////////
+	
+	/*
+	 * Note:
+	 * This does NOT replace locking the whole registry over a not to be "disrupted" process like loading
+	 * (See BinaryLoader#get).
+	 * This is just an internal lock to keep things consistent on a technical level.
+	 * Locking the registry itself continously accross a whole process keeps things consistent
+	 * on a business-logical level.
+	 * Also note:
+	 * The methode #processLiveObjectIds and #selectLiveObjectIds do not and MAY NOT lock the whole registry
+	 * instance or it will create a deadlock with a loading process locking the registry and waiting for the
+	 * load task to complete.
+	 */
+	private final Object mutex = new Object();
 	
 	private Entry[] oidHashTable;
 	private Entry[] refHashTable;
@@ -194,179 +216,218 @@ public final class DefaultObjectRegistry implements PersistenceObjectRegistry
 	// methods //
 	////////////
 
-	private int internalHashLength()
+	/* note on naming:
+	 * 
+	 * All instance methods not starting with "synch~" must protected their logic
+	 * by using a synchronized block synchronizing on the mutex instance.
+	 * 
+	 * AND
+	 * 
+	 * All instance methods starting with "synch~" must be called
+	 * either
+	 * 1.) inside a synchronized block
+	 * OR
+	 * 2.) by another method prefixed "synch~".
+	 * 
+	 * With this simple naming convention, it can be very easily checked if there
+	 * are no loopholes in the concurrency handling architecture of this class.
+	 */
+
+	private int synchHashLength()
 	{
 		return this.hashRange + 1;
 	}
 	
-	private void internalSetHashDensity(final float validHashDensity)
+	private void synchSetHashDensity(final float validHashDensity)
 	{
 		this.hashDensity = validHashDensity;
 	}
 	
-	private void internalSetMinimumCapacity(final long validMinimumCapacity)
+	private void synchSetMinimumCapacity(final long validMinimumCapacity)
 	{
 		this.minCapacity = validMinimumCapacity;
 	}
 	
-	final DefaultObjectRegistry internalSetConfiguration(
+	final DefaultObjectRegistry synchSetConfiguration(
 		final float hashDensity    ,
 		final long  minimumCapacity
 	)
 	{
-		this.internalSetHashDensity(hashDensity);
-		this.internalSetMinimumCapacity(minimumCapacity);
+		this.synchSetHashDensity(hashDensity);
+		this.synchSetMinimumCapacity(minimumCapacity);
 		
 		return this;
 	}
 	
-	final DefaultObjectRegistry internalReset()
+	final DefaultObjectRegistry synchReset()
 	{
-		return this.internalReset(this.minCapacity);
+		return this.synchReset(this.minCapacity);
 	}
 	
-	final DefaultObjectRegistry internalReset(final long minimumCapacity)
+	final DefaultObjectRegistry synchReset(final long minimumCapacity)
 	{
 		this.size = 0;
-		final int hashLength = this.calculateRequiredHashLength(minimumCapacity);
-		this.setHashTables(
-			this.createHashTable(hashLength),
-			this.createHashTable(hashLength)
+		final int hashLength = calculateRequiredHashLength(minimumCapacity, this.hashDensity);
+		this.synchSetHashTables(
+			createHashTable(hashLength),
+			createHashTable(hashLength)
 		);
 				
 		return this;
 	}
-	
-	private int calculateRequiredHashLength(final long minimumCapacity)
-	{
-		return XHashing.padHashLength((long)(minimumCapacity / this.hashDensity));
-	}
 		
-	private void setHashTables(final Entry[] oidHashTable, final Entry[] refHashTable)
+	private void synchSetHashTables(final Entry[] oidHashTable, final Entry[] refHashTable)
 	{
 		this.oidHashTable = oidHashTable;
 		this.refHashTable = refHashTable;
 		this.hashRange    = oidHashTable.length - 1;
-		this.internalUpdateCapacity();
-	}
-		
-	private Entry[] createHashTable(final int hashLength)
-	{
-		return new Entry[hashLength];
+		this.synchUpdateCapacity();
 	}
 	
-	private void internalUpdateCapacity()
+	private void synchUpdateCapacity()
 	{
-		this.capacity = this.internalHashLength() >= XMath.highestPowerOf2_int()
+		this.capacity = this.synchHashLength() >= XMath.highestPowerOf2_int()
 			? Long.MAX_VALUE
-			: (long)(this.internalHashLength() * this.hashDensity)
+			: (long)(this.synchHashLength() * this.hashDensity)
 		;
 	}
 		
 	@Override
-	public final synchronized DefaultObjectRegistry Clone()
+	public final DefaultObjectRegistry Clone()
 	{
-		return DefaultObjectRegistry.New(this.hashDensity, this.minCapacity);
+		synchronized(this.mutex)
+		{
+			return DefaultObjectRegistry.New(this.hashDensity, this.minCapacity);
+		}
 	}
 
 	@Override
-	public final synchronized int hashRange()
+	public final int hashRange()
 	{
-		return this.oidHashTable.length;
+		synchronized(this.mutex)
+		{
+			return this.oidHashTable.length;
+		}
 	}
 
 	@Override
-	public final synchronized float hashDensity()
+	public final float hashDensity()
 	{
-		return this.hashDensity;
+		synchronized(this.mutex)
+		{
+			return this.hashDensity;
+		}
 	}
 	
 	@Override
-	public final synchronized long minimumCapacity()
+	public final long minimumCapacity()
 	{
-		return this.minCapacity;
+		synchronized(this.mutex)
+		{
+			return this.minCapacity;
+		}
 	}
 
 	@Override
-	public final synchronized long capacity()
+	public final long capacity()
 	{
-		return this.capacity;
+		synchronized(this.mutex)
+		{
+			return this.capacity;
+		}
 	}
 
 	@Override
-	public final synchronized long size()
+	public final long size()
 	{
-		return this.size;
+		synchronized(this.mutex)
+		{
+			return this.size;
+		}
 	}
 
 	@Override
-	public final synchronized boolean isEmpty()
+	public final boolean isEmpty()
 	{
-		return this.size == 0;
+		synchronized(this.mutex)
+		{
+			return this.size == 0;
+		}
+	}
+
+	@Override
+	public final boolean setHashDensity(final float hashDensity)
+	{
+		synchronized(this.mutex)
+		{
+			this.synchSetHashDensity(validateHashDensity(hashDensity));
+			this.synchUpdateCapacity();
+			return this.ensureCapacity(this.minCapacity);
+		}
 	}
 	
 	@Override
-	public final synchronized boolean setHashDensity(final float hashDensity)
-	{
-		this.internalSetHashDensity(validateHashDensity(hashDensity));
-		
-		this.internalUpdateCapacity();
-		return this.ensureCapacity(this.minCapacity);
-	}
-	
-	@Override
-	public final synchronized boolean setConfiguration(
+	public final boolean setConfiguration(
 		final float hashDensity    ,
 		final long  minimumCapacity
 	)
 	{
-		// both values are checked before modifying any state
-		validateHashDensity(hashDensity);
-		validateCapacity(minimumCapacity);
-		
-		this.internalSetHashDensity(hashDensity);
-		this.internalSetMinimumCapacity(minimumCapacity);
-		
-		this.internalUpdateCapacity();
-		return this.ensureCapacity(minimumCapacity);
-	}
-	
-	@Override
-	public final synchronized boolean setMinimumCapacity(final long minimumCapacity)
-	{
-		this.internalSetMinimumCapacity(validateCapacity(minimumCapacity));
-		
-		this.internalUpdateCapacity();
-		return this.ensureCapacity(minimumCapacity);
-	}
-	
-	@Override
-	public final synchronized boolean ensureCapacity(final long desiredCapacity)
-	{
-		/*
-		 * Cannot use capacityHigh here, as this method is called after changing capacity-defining values.
-		 * Instead, the actual hash length is checked to determine if the tables really are too small.
-		 */
-		
-		validateCapacity(desiredCapacity);
-		final int requiredHashLength = this.calculateRequiredHashLength(desiredCapacity);
-		if(requiredHashLength > this.internalHashLength())
+		synchronized(this.mutex)
 		{
-			this.internalRebuild(requiredHashLength);
-			
-			return true;
+			// both values are checked before modifying any state
+			validateHashDensity(hashDensity);
+			validateCapacity(minimumCapacity);
+
+			this.synchSetHashDensity(hashDensity);
+			this.synchSetMinimumCapacity(minimumCapacity);
+
+			this.synchUpdateCapacity();
+			return this.ensureCapacity(minimumCapacity);
 		}
-		
-		return false;
+	}
+	
+	@Override
+	public final boolean setMinimumCapacity(final long minimumCapacity)
+	{
+		synchronized(this.mutex)
+		{
+			this.synchSetMinimumCapacity(validateCapacity(minimumCapacity));
+			this.synchUpdateCapacity();
+			return this.ensureCapacity(minimumCapacity);
+		}
+	}
+	
+	@Override
+	public final boolean ensureCapacity(final long desiredCapacity)
+	{
+		synchronized(this.mutex)
+		{
+			/*
+			 * Cannot use capacityHigh here, as this method is called after changing capacity-defining values.
+			 * Instead, the actual hash length is checked to determine if the tables really are too small.
+			 */
+			validateCapacity(desiredCapacity);
+			final int requiredHashLength = calculateRequiredHashLength(desiredCapacity, this.hashDensity);
+			if(requiredHashLength > this.synchHashLength())
+			{
+				this.synchRebuild(requiredHashLength);
+				return true;
+			}
+
+			return false;
+		}
 	}
 
 	@Override
-	public final synchronized boolean containsObjectId(final long objectId)
+	public final boolean containsObjectId(final long objectId)
 	{
-		return this.internalContainsObjectId(objectId);
+		synchronized(this.mutex)
+		{
+			return this.synchContainsObjectId(objectId);
+		}
 	}
 
-	private boolean internalContainsObjectId(final long objectId)
+	private boolean synchContainsObjectId(final long objectId)
 	{
 		for(Entry e = this.oidHashTable[(int)objectId & this.hashRange]; e != null; e = e.oidNext)
 		{
@@ -380,19 +441,20 @@ public final class DefaultObjectRegistry implements PersistenceObjectRegistry
 	}
 	
 	@Override
-	public final synchronized long lookupObjectId(final Object object)
+	public final long lookupObjectId(final Object object)
 	{
-		if(object == null)
+		synchronized(this.mutex)
 		{
-			throw new NullPointerException();
+			if(object == null)
+			{
+				throw new NullPointerException();
+			}
+			return this.synchLookupObjectId(object);
 		}
-		
-		return this.internalLookupObjectId(object);
 	}
 	
-	private long internalLookupObjectId(final Object object)
+	private long synchLookupObjectId(final Object object)
 	{
-
 		for(Entry e = this.refHashTable[hash(object) & this.hashRange]; e != null; e = e.refNext)
 		{
 			if(e.get() == object)
@@ -405,12 +467,15 @@ public final class DefaultObjectRegistry implements PersistenceObjectRegistry
 	}
 
 	@Override
-	public final synchronized Object lookupObject(final long objectId)
+	public final Object lookupObject(final long objectId)
 	{
-		return this.internalLookupObject(objectId);
+		synchronized(this.mutex)
+		{
+			return this.synchLookupObject(objectId);
+		}
 	}
 	
-	private Object internalLookupObject(final long objectId)
+	private Object synchLookupObject(final long objectId)
 	{
 		for(Entry e = this.oidHashTable[(int)objectId & this.hashRange]; e != null; e = e.oidNext)
 		{
@@ -426,15 +491,21 @@ public final class DefaultObjectRegistry implements PersistenceObjectRegistry
 	@Override
 	public final boolean isValid(final long objectId, final Object object)
 	{
-		// hacky flag, but no idea how to better prevent the code redundancy except with abstraction overkill.
-		return this.synchInternalValidate(objectId, object, false);
+		synchronized(this.mutex)
+		{
+			// hacky flag, but no idea how to better prevent the code redundancy except with abstraction overkill.
+			return this.synchInternalValidate(objectId, object, false);
+		}
 	}
 	
 	@Override
-	public final synchronized void validate(final long objectId, final Object object)
+	public final void validate(final long objectId, final Object object)
 	{
-		// hacky flag, but no idea how to better prevent the code redundancy except with abstraction overkill.
-		this.synchInternalValidate(objectId, object, true);
+		synchronized(this.mutex)
+		{
+			// hacky flag, but no idea how to better prevent the code redundancy except with abstraction overkill.
+			this.synchInternalValidate(objectId, object, true);
+		}
 	}
 	
 	private boolean synchInternalValidate(final long objectId, final Object object, final boolean throwException)
@@ -444,7 +515,7 @@ public final class DefaultObjectRegistry implements PersistenceObjectRegistry
 			throw new NullPointerException();
 		}
 		
-		final long registeredObjectId = this.internalLookupObjectId(object);
+		final long registeredObjectId = this.synchLookupObjectId(object);
 		if(registeredObjectId == objectId)
 		{
 			// already registered entry
@@ -453,7 +524,7 @@ public final class DefaultObjectRegistry implements PersistenceObjectRegistry
 		
 		if(Swizzling.isNotFoundId(registeredObjectId))
 		{
-			final Object registeredObject = this.internalLookupObject(objectId);
+			final Object registeredObject = this.synchLookupObject(objectId);
 			if(registeredObject == null)
 			{
 				// consistently not registered object
@@ -479,7 +550,15 @@ public final class DefaultObjectRegistry implements PersistenceObjectRegistry
 	}
 	
 	@Override
-	public final synchronized boolean registerObject(final long objectId, final Object object)
+	public final boolean registerObject(final long objectId, final Object object)
+	{
+		synchronized(this.mutex)
+		{
+			return this.synchRegisterObject(objectId, object);
+		}
+	}
+
+	private boolean synchRegisterObject(final long objectId, final Object object)
 	{
 		if(object == null)
 		{
@@ -489,57 +568,63 @@ public final class DefaultObjectRegistry implements PersistenceObjectRegistry
 		{
 			throw new PersistenceExceptionImproperObjectId();
 		}
-
-		return this.internalAdd(objectId, object);
+		return this.synchAdd(objectId, object);
 	}
 
 	@Override
-	public final synchronized Object optionalRegisterObject(final long objectId, final Object object)
+	public final Object optionalRegisterObject(final long objectId, final Object object)
 	{
-		if(object == null)
+		synchronized(this.mutex)
 		{
-			throw new NullPointerException();
+			if(object == null)
+			{
+				throw new NullPointerException();
+			}
+			if(Swizzling.isNotProperId(objectId))
+			{
+				throw new PersistenceExceptionImproperObjectId();
+			}
+			return this.synchAddGet(objectId, object);
 		}
-		if(Swizzling.isNotProperId(objectId))
-		{
-			throw new PersistenceExceptionImproperObjectId();
-		}
-		
-		return this.internalAddGet(objectId, object);
 	}
 	
 	@Override
-	public final synchronized boolean registerConstant(final long objectId, final Object constant)
+	public final boolean registerConstant(final long objectId, final Object constant)
 	{
-		if(!this.registerObject(objectId, constant))
+		synchronized(this.mutex)
 		{
-			return false;
+			if(!this.synchRegisterObject(objectId, constant))
+			{
+				return false;
+			}
+			this.synchEnsureConstantsHotRegistry().add(objectId, constant);
+
+			return true;
 		}
-		
-		this.ensureConstantsHotRegistry().add(objectId, constant);
-		
-		return true;
 	}
 
 	@Override
-	public final synchronized <A extends PersistenceAcceptor> A iterateEntries(final A acceptor)
+	public final <A extends PersistenceAcceptor> A iterateEntries(final A acceptor)
 	{
-		iterateEntries(this.oidHashTable, acceptor);
-		return acceptor;
+		synchronized(this.mutex)
+		{
+			iterateEntries(this.oidHashTable, acceptor);
+			return acceptor;
+		}
 	}
 		
-	private boolean internalAdd(final long objectId, final Object object)
+	private boolean synchAdd(final long objectId, final Object object)
 	{
-		if(this.internalAddCheck(objectId, object))
+		if(this.synchAddCheck(objectId, object))
 		{
 			return false;
 		}
 
-		this.internalPutNewEntry(objectId, object);
+		this.synchPutNewEntry(objectId, object);
 		return true;
 	}
 		
-	private void internalPutNewEntry(final long objectId, final Object object)
+	private void synchPutNewEntry(final long objectId, final Object object)
 	{
 		this.oidHashTable[(int)objectId & this.hashRange] =
 		this.refHashTable[ hash(object) & this.hashRange] =
@@ -550,28 +635,28 @@ public final class DefaultObjectRegistry implements PersistenceObjectRegistry
 				this.refHashTable[ hash(object) & this.hashRange]
 			)
 		;
-		
+
 		if(++this.size > this.capacity)
 		{
-			this.internalIncreaseStorage();
+			this.synchIncreaseStorage();
 		}
 	}
 	
-	private boolean internalAddCheck(final long objectId, final Object object)
+	private boolean synchAddCheck(final long objectId, final Object object)
 	{
 		for(Entry e = this.oidHashTable[(int)objectId & this.hashRange]; e != null; e = e.oidNext)
 		{
 			if(e.objectId == objectId)
 			{
-				return this.internalHandleExisting(object, e);
+				return this.synchHandleExisting(object, e);
 			}
 		}
 
-		this.internalValidateObjectNotYetRegistered(objectId, object);
+		this.synchValidateObjectNotYetRegistered(objectId, object);
 		return false;
 	}
 	
-	private Object internalAddGetCheck(final long objectId, final Object object)
+	private Object synchAddGetCheck(final long objectId, final Object object)
 	{
 		for(Entry e = this.oidHashTable[(int)objectId & this.hashRange]; e != null; e = e.oidNext)
 		{
@@ -584,18 +669,18 @@ public final class DefaultObjectRegistry implements PersistenceObjectRegistry
 				}
 
 				// orphan entry removal is always right, even in case of an error.
-				this.internalRemoveEntry(e);
+				this.synchRemoveEntry(e);
 				break;
 			}
 		}
 
 		// either no hash chain yet or no (live) entry for that objectId. Validate and signal need for registration.
-		this.internalValidateObjectNotYetRegistered(objectId, object);
-		
+		this.synchValidateObjectNotYetRegistered(objectId, object);
+
 		return null;
 	}
 	
-	private boolean internalHandleExisting(final Object object, final Entry entry)
+	private boolean synchHandleExisting(final Object object, final Entry entry)
 	{
 		if(entry.get() == object)
 		{
@@ -606,14 +691,14 @@ public final class DefaultObjectRegistry implements PersistenceObjectRegistry
 		{
 			throw new PersistenceExceptionConsistencyObject(entry.objectId, entry.get(), object);
 		}
-		
-		this.internalValidateObjectNotYetRegistered(entry.objectId, object);
-		this.internalRemoveEntry(entry);
-		
+
+		this.synchValidateObjectNotYetRegistered(entry.objectId, object);
+		this.synchRemoveEntry(entry);
+
 		return false;
 	}
 	
-	private void internalRemoveEntry(final Entry entry)
+	private void synchRemoveEntry(final Entry entry)
 	{
 		removeFromOidTable(this.oidHashTable, (int)entry.objectId & this.hashRange, entry);
 		removeFromRefTable(this.refHashTable,      entry.refHash  & this.hashRange, entry);
@@ -656,7 +741,7 @@ public final class DefaultObjectRegistry implements PersistenceObjectRegistry
 		}
 	}
 		
-	private void internalValidateObjectNotYetRegistered(final long objectId, final Object object)
+	private void synchValidateObjectNotYetRegistered(final long objectId, final Object object)
 	{
 		final int refHash = hash(object);
 		for(Entry e = this.refHashTable[refHash & this.hashRange]; e != null; e = e.refNext)
@@ -669,22 +754,30 @@ public final class DefaultObjectRegistry implements PersistenceObjectRegistry
 		}
 	}
 
-	private Object internalAddGet(final long objectId, final Object object)
+	private Object synchAddGet(final long objectId, final Object object)
 	{
 		final Object alreadyRegistered;
-		if((alreadyRegistered = this.internalAddGetCheck(objectId, object)) != null)
+		if((alreadyRegistered = this.synchAddGetCheck(objectId, object)) != null)
 		{
 			return alreadyRegistered;
 		}
 
-		this.internalPutNewEntry(objectId, object);
+		this.synchPutNewEntry(objectId, object);
 		return object;
 	}
 	
 	// rebuilding and consolidation //
 	
 	@Override
-	public final synchronized boolean consolidate()
+	public final boolean consolidate()
+	{
+		synchronized(this.mutex)
+		{
+			return this.synchConsolidate();
+		}
+	}
+
+	private boolean synchConsolidate()
 	{
 		// both tables always have the same length
 		final Entry[] oidHashTable = this.oidHashTable;
@@ -757,43 +850,42 @@ public final class DefaultObjectRegistry implements PersistenceObjectRegistry
 		
 	private boolean checkForDecrease()
 	{
-		final int requiredHashLength = this.calculateRequiredHashLength(this.size);
-		if(requiredHashLength != this.internalHashLength())
+		final int requiredHashLength = calculateRequiredHashLength(this.size, this.hashDensity);
+		if(requiredHashLength != this.synchHashLength())
 		{
-			this.internalRebuild(requiredHashLength);
-			
+			this.synchRebuild(requiredHashLength);
 			return true;
 		}
-		
+
 		return false;
 	}
 	
-	private void internalIncreaseStorage()
+	private void synchIncreaseStorage()
 	{
 		// capacityHighBound checks prevent unnecessary / dangerous calls of this method
-		this.internalRebuild(this.oidHashTable.length << 1);
+		this.synchRebuild(this.oidHashTable.length << 1);
 	}
 	
-	private void internalRebuild(final int hashLength)
+	private void synchRebuild(final int hashLength)
 	{
-		final Entry[] newOidHashTable = this.createHashTable(hashLength);
-		final Entry[] newRefHashTable = this.createHashTable(hashLength);
+		final Entry[] newOidHashTable = createHashTable(hashLength);
+		final Entry[] newRefHashTable = createHashTable(hashLength);
 
 		// orphaned entries are discarded and their total count is returned to be subtracted here.
 		this.size -= rebuildTables(this.oidHashTable, newOidHashTable, newRefHashTable);
-		
+
 		// the new hash tables are set as the instance's storage structure.
-		this.setHashTables(newOidHashTable, newRefHashTable);
-		
+		this.synchSetHashTables(newOidHashTable, newRefHashTable);
+
 		/*
 		 * Since rebuilding discards orphaned entries and reduces the size, it could be possible that
 		 * a rebuild to increase the storage determines that it could actually shrink.
 		 * The doubled performance cost in such cases should be well worth the automatic memory saving.
 		 */
 		this.checkForDecrease();
-		
+
 		// at some point, constant registration is completed, so an efficient storage form is preferable.
-		this.internalEnsureConstantsColdStorage();
+		this.synchEnsureConstantsColdStorage();
 	}
 
 	private static long rebuildTables(
@@ -861,20 +953,26 @@ public final class DefaultObjectRegistry implements PersistenceObjectRegistry
 	// clearing //
 	
 	@Override
-	public final synchronized void clear()
+	public final void clear()
 	{
-		this.internalEnsureConstantsColdStorage();
-		this.internalClear();
-		this.internalReregisterConstants();
+		synchronized(this.mutex)
+		{
+			this.synchEnsureConstantsColdStorage();
+			this.synchClear();
+			this.synchReregisterConstants();
+		}
 	}
 	
 	@Override
-	public final synchronized void clearAll()
+	public final void clearAll()
 	{
-		this.internalClear();
+		synchronized(this.mutex)
+		{
+			this.synchClear();
+		}
 	}
-	
-	private void internalClear()
+
+	private void synchClear()
 	{
 		final Entry[] oidBuckets = this.oidHashTable;
 		final Entry[] refBuckets = this.refHashTable;
@@ -888,48 +986,55 @@ public final class DefaultObjectRegistry implements PersistenceObjectRegistry
 	}
 
 	@Override
-	public final synchronized void truncate()
+	public final void truncate()
 	{
-		// reinitialize storage strucuture with at least enough capacity for the incoming constants.
-		this.internalEnsureConstantsColdStorage();
-		
-		this.internalReset(Math.max(this.constantsColdStorageObjects.length, this.minCapacity));
-		
-		this.internalReregisterConstants();
+		synchronized(this.mutex)
+		{
+			// reinitialize storage strucuture with at least enough capacity for the incoming constants.
+			this.synchEnsureConstantsColdStorage();
+			this.synchReset(Math.max(this.constantsColdStorageObjects.length, this.minCapacity));
+			this.synchReregisterConstants();
+		}
 	}
 	
 	@Override
-	public final synchronized void truncateAll()
+	public final void truncateAll()
 	{
-		// hash table reset, no constants reregistering.
-		this.internalReset();
+		synchronized(this.mutex)
+		{
+			// hash table reset, no constants reregistering.
+			this.synchReset();
+		}
 	}
 	
 	// Constants handling //
 	
-	private void internalReregisterConstants()
+	private void synchReregisterConstants()
 	{
-		final Object[] constantsObjects = this.constantsColdStorageObjects;
-		final long[] constantsObjectIds = this.constantsColdStorageObjectIds;
-		
-		for(int i = 0; i < constantsObjects.length; i++)
+		synchronized(this.mutex)
 		{
-			// NOT registerConstant() at this point!
-			this.registerObject(constantsObjectIds[i], constantsObjects[i]);
+			final Object[] constantsObjects = this.constantsColdStorageObjects;
+			final long[] constantsObjectIds = this.constantsColdStorageObjectIds;
+
+			for(int i = 0; i < constantsObjects.length; i++)
+			{
+				// NOT registerConstant() at this point!
+				this.synchRegisterObject(constantsObjectIds[i], constantsObjects[i]);
+			}
 		}
 	}
 	
-	private EqHashTable<Long, Object> ensureConstantsHotRegistry()
+	private EqHashTable<Long, Object> synchEnsureConstantsHotRegistry()
 	{
 		if(this.constantsHotRegistry == null)
 		{
-			this.internalBuildConstantsHotRegistry();
+			this.synchBuildConstantsHotRegistry();
 		}
-		
+
 		return this.constantsHotRegistry;
 	}
 	
-	private void internalBuildConstantsHotRegistry()
+	private void synchBuildConstantsHotRegistry()
 	{
 		final EqHashTable<Long, Object> constantsHotRegistry = EqHashTable.New();
 		
@@ -947,17 +1052,17 @@ public final class DefaultObjectRegistry implements PersistenceObjectRegistry
 		this.constantsColdStorageObjectIds = null;
 	}
 	
-	private void internalEnsureConstantsColdStorage()
+	private void synchEnsureConstantsColdStorage()
 	{
 		if(this.constantsColdStorageObjects != null)
 		{
 			return;
 		}
-		
-		this.internalBuildConstantsColdStorage();
+
+		this.synchBuildConstantsColdStorage();
 	}
-	
-	private void internalBuildConstantsColdStorage()
+
+	private void synchBuildConstantsColdStorage()
 	{
 		
 		final EqHashTable<Long, Object> constantsHotRegistry = this.constantsHotRegistry;
@@ -980,43 +1085,47 @@ public final class DefaultObjectRegistry implements PersistenceObjectRegistry
 	}
 	
 	@Override
-	public synchronized <P extends ObjectIdsProcessor> P processLiveObjectIds(final P processor)
+	public boolean processLiveObjectIds(final ObjectIdsProcessor processor)
 	{
-		processor.processObjectIdsByFilter(this::isLiveObjectId);
-
-		return processor;
+		synchronized(this.mutex)
+		{
+			processor.processObjectIdsByFilter(this::synchIsLiveObjectId);
+			return true;
+		}
 	}
 
-	@Override
-	public synchronized Set_long selectLiveObjectIds(final Set_long objectIdsBaseSet)
+	final boolean synchIsLiveObjectId(final long objectId)
 	{
-		return objectIdsBaseSet.filter(this::isLiveObjectId);
-	}
-
-	final boolean isLiveObjectId(final long objectId)
-	{
-		final boolean result = this.internalContainsObjectId(objectId);
-
+		final boolean result = this.synchContainsObjectId(objectId);
 //		XDebug.println("ObjectRegistry checking OID " + objectId + ": " + result);
 
 		return result;
+	}
 
-		// debug hook call
-//		return this.internalContainsObjectId(objectId);
+	@Override
+	public Set_long selectLiveObjectIds(final Set_long objectIdsBaseSet)
+	{
+		synchronized(this.mutex)
+		{
+			return objectIdsBaseSet.filter(this::synchIsLiveObjectId);
+		}
 	}
 	
 	// HashStatistics //
 	
 	@Override
-	public final synchronized XGettingTable<String, HashStatisticsBucketBased> createHashStatistics()
+	public final XGettingTable<String, HashStatisticsBucketBased> createHashStatistics()
 	{
-		return EqHashTable.New(
-			KeyValue("PerObjectIds", this.internalCreateHashStatisticsOids()),
-			KeyValue("PerObjects", this.internalCreateHashStatisticsRefs())
-		);
+		synchronized(this.mutex)
+		{
+			return EqHashTable.New(
+				KeyValue("PerObjectIds", this.synchCreateHashStatisticsOids()),
+				KeyValue("PerObjects"  , this.synchCreateHashStatisticsRefs())
+			);
+		}
 	}
 	
-	private HashStatisticsBucketBased internalCreateHashStatisticsOids()
+	private HashStatisticsBucketBased synchCreateHashStatisticsOids()
 	{
 		final EqHashTable<Long, Long> distributionTable = EqHashTable.New();
 		
@@ -1037,7 +1146,7 @@ public final class DefaultObjectRegistry implements PersistenceObjectRegistry
 		);
 	}
 
-	private HashStatisticsBucketBased internalCreateHashStatisticsRefs()
+	private HashStatisticsBucketBased synchCreateHashStatisticsRefs()
 	{
 		final EqHashTable<Long, Long> distributionTable = EqHashTable.New();
 

--- a/persistence/persistence/src/main/java/one/microstream/persistence/types/ObjectIdSelection.java
+++ b/persistence/persistence/src/main/java/one/microstream/persistence/types/ObjectIdSelection.java
@@ -1,5 +1,25 @@
 package one.microstream.persistence.types;
 
+/*-
+ * #%L
+ * MicroStream Persistence
+ * %%
+ * Copyright (C) 2019 - 2022 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is
+ * available at https://www.gnu.org/software/classpath/license.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * #L%
+ */
+
 import static one.microstream.X.notNull;
 
 import one.microstream.collections.Set_long;

--- a/persistence/persistence/src/main/java/one/microstream/persistence/types/ObjectIdSelection.java
+++ b/persistence/persistence/src/main/java/one/microstream/persistence/types/ObjectIdSelection.java
@@ -1,0 +1,56 @@
+package one.microstream.persistence.types;
+
+import static one.microstream.X.notNull;
+
+import one.microstream.collections.Set_long;
+import one.microstream.functional._longPredicate;
+
+public interface ObjectIdSelection extends _longPredicate
+{
+	@Override
+	public boolean test(long objectId);
+
+
+
+	public static ObjectIdSelection New(final Set_long objectIds)
+	{
+		return new ObjectIdSelection.Default(
+			notNull(objectIds)
+		);
+	}
+
+	public final class Default implements ObjectIdSelection
+	{
+		///////////////////////////////////////////////////////////////////////////
+		// instance fields //
+		////////////////////
+
+		private final Set_long objectIds;
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// constructors //
+		/////////////////
+
+		Default(final Set_long objectIds)
+		{
+			super();
+			this.objectIds = objectIds;
+		}
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// methods //
+		////////////
+
+		@Override
+		public final boolean test(final long objectId)
+		{
+			return this.objectIds.contains(objectId);
+		}
+
+	}
+
+}

--- a/persistence/persistence/src/main/java/one/microstream/persistence/types/ObjectIdsProcessor.java
+++ b/persistence/persistence/src/main/java/one/microstream/persistence/types/ObjectIdsProcessor.java
@@ -1,5 +1,25 @@
 package one.microstream.persistence.types;
 
+/*-
+ * #%L
+ * MicroStream Persistence
+ * %%
+ * Copyright (C) 2019 - 2022 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is
+ * available at https://www.gnu.org/software/classpath/license.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * #L%
+ */
+
 import one.microstream.collections.Set_long;
 import one.microstream.functional._longPredicate;
 

--- a/persistence/persistence/src/main/java/one/microstream/persistence/types/ObjectIdsProcessor.java
+++ b/persistence/persistence/src/main/java/one/microstream/persistence/types/ObjectIdsProcessor.java
@@ -1,0 +1,13 @@
+package one.microstream.persistence.types;
+
+import one.microstream.collections.Set_long;
+import one.microstream.functional._longPredicate;
+
+public interface ObjectIdsProcessor
+{
+	// one-by-one processing of objectIds. Efficient for embedded mode, horribly inefficient for server mode.
+	public void processObjectIdsByFilter(_longPredicate objectIdsSelector);
+
+	// for bulk processing of objectIds. Most efficient way for server mode, inefficient for embedded mode.
+	public Set_long provideObjectIdsBaseSet();
+}

--- a/persistence/persistence/src/main/java/one/microstream/persistence/types/ObjectIdsSelector.java
+++ b/persistence/persistence/src/main/java/one/microstream/persistence/types/ObjectIdsSelector.java
@@ -1,5 +1,25 @@
 package one.microstream.persistence.types;
 
+/*-
+ * #%L
+ * MicroStream Persistence
+ * %%
+ * Copyright (C) 2019 - 2022 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is
+ * available at https://www.gnu.org/software/classpath/license.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * #L%
+ */
+
 public interface ObjectIdsSelector
 {
 	public boolean processSelected(ObjectIdsProcessor processor);

--- a/persistence/persistence/src/main/java/one/microstream/persistence/types/ObjectIdsSelector.java
+++ b/persistence/persistence/src/main/java/one/microstream/persistence/types/ObjectIdsSelector.java
@@ -2,6 +2,6 @@ package one.microstream.persistence.types;
 
 public interface ObjectIdsSelector
 {
-	public void processSelected(ObjectIdsProcessor processor);
+	public boolean processSelected(ObjectIdsProcessor processor);
 
 }

--- a/persistence/persistence/src/main/java/one/microstream/persistence/types/ObjectIdsSelector.java
+++ b/persistence/persistence/src/main/java/one/microstream/persistence/types/ObjectIdsSelector.java
@@ -1,0 +1,7 @@
+package one.microstream.persistence.types;
+
+public interface ObjectIdsSelector
+{
+	public void processSelected(ObjectIdsProcessor processor);
+
+}

--- a/persistence/persistence/src/main/java/one/microstream/persistence/types/PersistenceLiveStorerRegistry.java
+++ b/persistence/persistence/src/main/java/one/microstream/persistence/types/PersistenceLiveStorerRegistry.java
@@ -1,5 +1,25 @@
 package one.microstream.persistence.types;
 
+/*-
+ * #%L
+ * MicroStream Persistence
+ * %%
+ * Copyright (C) 2019 - 2022 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is
+ * available at https://www.gnu.org/software/classpath/license.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * #L%
+ */
+
 import one.microstream.collections.EqHashTable;
 import one.microstream.collections.HashEnum;
 

--- a/persistence/persistence/src/main/java/one/microstream/persistence/types/PersistenceLiveStorerRegistry.java
+++ b/persistence/persistence/src/main/java/one/microstream/persistence/types/PersistenceLiveStorerRegistry.java
@@ -1,5 +1,9 @@
 package one.microstream.persistence.types;
 
+import org.slf4j.Logger;
+
+import one.microstream.chars.XChars;
+
 /*-
  * #%L
  * MicroStream Persistence
@@ -22,6 +26,7 @@ package one.microstream.persistence.types;
 
 import one.microstream.collections.EqHashTable;
 import one.microstream.collections.HashEnum;
+import one.microstream.util.logging.Logging;
 
 public interface PersistenceLiveStorerRegistry extends PersistenceStorer.CreationObserver
 {
@@ -44,6 +49,8 @@ public interface PersistenceLiveStorerRegistry extends PersistenceStorer.Creatio
 
 	public final class Default implements PersistenceLiveStorerRegistry
 	{
+		private final static Logger logger = Logging.getLogger(PersistenceLiveStorerRegistry.class);
+		
 		///////////////////////////////////////////////////////////////////////////
 		// instance fields //
 		////////////////////
@@ -77,7 +84,8 @@ public interface PersistenceLiveStorerRegistry extends PersistenceStorer.Creatio
 				this.storerGroups.add(this.currentGroupId, storerGroup = HashEnum.New());
 			}
 
-//			XDebug.print("Registering storer " + XChars.systemString(storer) + " to id Group " + this.currentGroupId);
+			logger.debug("Registering storer " + XChars.systemString(storer) + " to id Group " + this.currentGroupId);
+			
 			storerGroup.add(storer);
 		}
 
@@ -86,7 +94,7 @@ public interface PersistenceLiveStorerRegistry extends PersistenceStorer.Creatio
 		{
 			final long removeCount = this.storerGroups.removeBy(e -> e.key() <= oldGroupId);
 
-//			XDebug.println(Thread.currentThread() + " removed " + removeCount + " idGroups with id <= " + oldGroupId + ".");
+			logger.debug(Thread.currentThread() + " removed " + removeCount + " idGroups with id <= " + oldGroupId + ".");
 
 			this.currentGroupId = newGroupId;
 

--- a/persistence/persistence/src/main/java/one/microstream/persistence/types/PersistenceLiveStorerRegistry.java
+++ b/persistence/persistence/src/main/java/one/microstream/persistence/types/PersistenceLiveStorerRegistry.java
@@ -1,0 +1,78 @@
+package one.microstream.persistence.types;
+
+import one.microstream.collections.EqHashTable;
+import one.microstream.collections.HashEnum;
+
+public interface PersistenceLiveStorerRegistry extends PersistenceStorer.CreationObserver
+{
+	@Override
+	public default void observeCreatedStorer(final PersistenceStorer storer)
+	{
+		this.registerStorer(storer);
+	}
+
+	public void registerStorer(PersistenceStorer storer);
+
+	public boolean clearGroupAndAdvance(long oldGroupId, long newGroupId);
+
+
+
+	public static PersistenceLiveStorerRegistry New()
+	{
+		return new PersistenceLiveStorerRegistry.Default();
+	}
+
+	public final class Default implements PersistenceLiveStorerRegistry
+	{
+		///////////////////////////////////////////////////////////////////////////
+		// instance fields //
+		////////////////////
+
+		private final EqHashTable<Long, HashEnum<PersistenceStorer>> storerGroups = EqHashTable.New();
+		private long currentGroupId;
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// constructors //
+		/////////////////
+
+		Default()
+		{
+			super();
+		}
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// methods //
+		////////////
+
+		@Override
+		public synchronized void registerStorer(final PersistenceStorer storer)
+		{
+			HashEnum<PersistenceStorer> storerGroup = this.storerGroups.get(this.currentGroupId);
+			if(storerGroup == null)
+			{
+				this.storerGroups.add(this.currentGroupId, storerGroup = HashEnum.New());
+			}
+
+//			XDebug.print("Registering storer " + XChars.systemString(storer) + " to id Group " + this.currentGroupId);
+			storerGroup.add(storer);
+		}
+
+		@Override
+		public synchronized boolean clearGroupAndAdvance(final long oldGroupId, final long newGroupId)
+		{
+			final long removeCount = this.storerGroups.removeBy(e -> e.key() <= oldGroupId);
+
+//			XDebug.println(Thread.currentThread() + " removed " + removeCount + " idGroups with id <= " + oldGroupId + ".");
+
+			this.currentGroupId = newGroupId;
+
+			return removeCount > 0;
+		}
+
+	}
+
+}

--- a/persistence/persistence/src/main/java/one/microstream/persistence/types/PersistenceObjectRegistry.java
+++ b/persistence/persistence/src/main/java/one/microstream/persistence/types/PersistenceObjectRegistry.java
@@ -1,5 +1,7 @@
 package one.microstream.persistence.types;
 
+import one.microstream.collections.Set_long;
+
 /*-
  * #%L
  * microstream-persistence
@@ -155,6 +157,12 @@ public interface PersistenceObjectRegistry extends PersistenceSwizzlingLookup, C
 	// removing logic is not viable except for testing purposes, which can be done implementation-specific.
 	
 	public XGettingTable<String, ? extends HashStatistics> createHashStatistics();
+	
+	// one-by-one processing of objectIds. Efficient for embedded mode, horribly inefficient for server mode.
+	public <P extends ObjectIdsProcessor> P processLiveObjectIds(P processor);
+
+	// for bulk processing of objectIds. Most efficient way for server mode, inefficient for embedded mode.
+	public Set_long selectLiveObjectIds(Set_long objectIdsBaseSet);
 	
 	
 	

--- a/persistence/persistence/src/main/java/one/microstream/persistence/types/PersistenceObjectRegistry.java
+++ b/persistence/persistence/src/main/java/one/microstream/persistence/types/PersistenceObjectRegistry.java
@@ -158,10 +158,19 @@ public interface PersistenceObjectRegistry extends PersistenceSwizzlingLookup, C
 	
 	public XGettingTable<String, ? extends HashStatistics> createHashStatistics();
 	
-	// one-by-one processing of objectIds. Efficient for embedded mode, horribly inefficient for server mode.
-	public <P extends ObjectIdsProcessor> P processLiveObjectIds(P processor);
+	/**
+	 * 
+	 * @param processor
+	 * @return <code>true</code> on success, <code>false</code> if lock rejected.
+	 */
+	public boolean processLiveObjectIds(ObjectIdsProcessor processor);
 
 	// for bulk processing of objectIds. Most efficient way for server mode, inefficient for embedded mode.
+	/**
+	 * 
+	 * @param objectIdsBaseSet
+	 * @return null if lock rejected
+	 */
 	public Set_long selectLiveObjectIds(Set_long objectIdsBaseSet);
 	
 	

--- a/persistence/persistence/src/main/java/one/microstream/persistence/types/PersistenceStorer.java
+++ b/persistence/persistence/src/main/java/one/microstream/persistence/types/PersistenceStorer.java
@@ -1,5 +1,7 @@
 package one.microstream.persistence.types;
 
+import static one.microstream.X.notNull;
+
 /*-
  * #%L
  * microstream-persistence
@@ -124,6 +126,67 @@ public interface PersistenceStorer extends Storer
 			PersistenceTarget<D>             target            ,
 			BufferSizeProviderIncremental    bufferSizeProvider
 		);
+	}
+	
+	
+	
+	@FunctionalInterface
+	public interface CreationObserver
+	{
+		public static void noOp(final PersistenceStorer storer)
+		{
+			// no-op
+		}
+
+		public void observeCreatedStorer(PersistenceStorer storer);
+
+
+		public static PersistenceStorer.CreationObserver Chain(
+			final CreationObserver first ,
+			final CreationObserver second
+		)
+		{
+			return new PersistenceStorer.CreationObserver.Chaining(
+				notNull(first) ,
+				notNull(second)
+			);
+		}
+
+		public final class Chaining implements PersistenceStorer.CreationObserver
+		{
+			///////////////////////////////////////////////////////////////////////////
+			// instance fields //
+			////////////////////
+
+			private final PersistenceStorer.CreationObserver first, second;
+
+
+
+			///////////////////////////////////////////////////////////////////////////
+			// constructors //
+			/////////////////
+
+			Chaining(final CreationObserver first, final CreationObserver second)
+			{
+				super();
+				this.first = first;
+				this.second = second;
+			}
+
+
+
+			///////////////////////////////////////////////////////////////////////////
+			// methods //
+			////////////
+
+			@Override
+			public void observeCreatedStorer(final PersistenceStorer storer)
+			{
+				this.first.observeCreatedStorer(storer);
+				this.second.observeCreatedStorer(storer);
+			}
+
+		}
 	}
 
 }

--- a/storage/embedded/src/main/java/one/microstream/storage/embedded/types/EmbeddedStorageConnectionFoundation.java
+++ b/storage/embedded/src/main/java/one/microstream/storage/embedded/types/EmbeddedStorageConnectionFoundation.java
@@ -316,7 +316,7 @@ extends BinaryPersistenceFoundation<F>
 			final PersistenceStorer.CreationObserver observer = this.getStorerCreationObserver();
 			if(observer == null)
 			{
-				// registry can simply be set as the (sole) obserber
+				// registry can simply be set as the (sole) observer
 				this.setStorerCreationObserver(storerRegistry);
 			}
 			else

--- a/storage/embedded/src/main/java/one/microstream/storage/embedded/types/EmbeddedStorageConnectionFoundation.java
+++ b/storage/embedded/src/main/java/one/microstream/storage/embedded/types/EmbeddedStorageConnectionFoundation.java
@@ -25,9 +25,14 @@ import static one.microstream.X.notNull;
 import java.util.function.Supplier;
 
 import one.microstream.exceptions.MissingFoundationPartException;
+import one.microstream.persistence.binary.types.Binary;
 import one.microstream.persistence.binary.types.BinaryLoader;
 import one.microstream.persistence.binary.types.BinaryPersistenceFoundation;
 import one.microstream.persistence.binary.types.BinaryStorer;
+import one.microstream.persistence.types.PersistenceLiveStorerRegistry;
+import one.microstream.persistence.types.PersistenceManager;
+import one.microstream.persistence.types.PersistenceStorer;
+import one.microstream.reference.Reference;
 import one.microstream.storage.types.StorageConnection;
 import one.microstream.storage.types.StorageRequestAcceptor;
 import one.microstream.storage.types.StorageSystem;
@@ -44,12 +49,24 @@ extends BinaryPersistenceFoundation<F>
 	public StorageWriteController writeController();
 	
 	public StorageWriteController getWriteController();
+	
+	public EmbeddedStorageObjectRegistryCallback getObjectRegistryCallback();
+
+	public Reference<PersistenceLiveStorerRegistry> getLiveStorerRegistryReference();
+
+	public PersistenceLiveStorerRegistry getLiveStorerRegistry();
 
 	public F setStorageSystem(StorageSystem storageSystem);
 	
 	public F setStorageSystemSupplier(Supplier<? extends StorageSystem> storageSystemSupplier);
 	
 	public F setWriteController(StorageWriteController writeController);
+	
+	public F setObjectRegistryCallback(EmbeddedStorageObjectRegistryCallback objectRegistryCallback);
+
+	public F setLiveStorerRegistryReference(Reference<PersistenceLiveStorerRegistry> storerRegistryReference);
+
+	public F setLiveStorerRegistry(PersistenceLiveStorerRegistry liveLiveStorerRegistry);
 	
 	public StorageConnection createStorageConnection();
 
@@ -68,10 +85,13 @@ extends BinaryPersistenceFoundation<F>
 		// instance fields //
 		////////////////////
 
-		private StorageSystem                     storageSystem         ;
-		private Supplier<? extends StorageSystem> storageSystemSupplier ;
-		private StorageWriteController            writeController       ;
-		private transient StorageRequestAcceptor  storageRequestAcceptor;
+		private StorageSystem                            storageSystem          ;
+		private Supplier<? extends StorageSystem>        storageSystemSupplier  ;
+		private StorageWriteController                   writeController        ;
+		private transient StorageRequestAcceptor         storageRequestAcceptor ;
+		private EmbeddedStorageObjectRegistryCallback    objectRegistryCallback ;
+		private Reference<PersistenceLiveStorerRegistry> storerRegistryReference;
+		private PersistenceLiveStorerRegistry            liveLiveStorerRegistry ;
 		
 		
 		
@@ -122,7 +142,36 @@ extends BinaryPersistenceFoundation<F>
 			return this.storageSystem;
 		}
 
+		@Override
+		public final EmbeddedStorageObjectRegistryCallback getObjectRegistryCallback()
+		{
+			if(this.objectRegistryCallback == null)
+			{
+				this.objectRegistryCallback = this.dispatch(this.ensureObjectRegistryCallback());
+			}
+			return this.objectRegistryCallback;
+		}
 
+		@Override
+		public final Reference<PersistenceLiveStorerRegistry> getLiveStorerRegistryReference()
+		{
+			if(this.storerRegistryReference == null)
+			{
+				this.storerRegistryReference = this.dispatch(this.ensureLiveStorerRegistryReference());
+			}
+			return this.storerRegistryReference;
+		}
+
+		@Override
+		public final PersistenceLiveStorerRegistry getLiveStorerRegistry()
+		{
+			if(this.liveLiveStorerRegistry == null)
+			{
+				this.liveLiveStorerRegistry = this.dispatch(this.ensureLiveStorerRegistry());
+			}
+			return this.liveLiveStorerRegistry;
+		}
+		
 
 		///////////////////////////////////////////////////////////////////////////
 		// setters //
@@ -152,6 +201,27 @@ extends BinaryPersistenceFoundation<F>
 			return this.$();
 		}
 		
+		@Override
+		public F setObjectRegistryCallback(final EmbeddedStorageObjectRegistryCallback objectRegistryCallback)
+		{
+			this.objectRegistryCallback = objectRegistryCallback;
+			return this.$();
+		}
+
+		@Override
+		public final F setLiveStorerRegistryReference(final Reference<PersistenceLiveStorerRegistry> storerRegistryReference)
+		{
+			this.storerRegistryReference = storerRegistryReference;
+			return this.$();
+		}
+
+		@Override
+		public final F setLiveStorerRegistry(final PersistenceLiveStorerRegistry liveLiveStorerRegistry)
+		{
+			this.liveLiveStorerRegistry = liveLiveStorerRegistry;
+			return this.$();
+		}
+		
 		
 		
 		///////////////////////////////////////////////////////////////////////////
@@ -171,6 +241,17 @@ extends BinaryPersistenceFoundation<F>
 			}
 			
 			throw new MissingFoundationPartException(StorageSystem.class);
+		}
+		
+		protected EmbeddedStorageObjectRegistryCallback ensureObjectRegistryCallback()
+		{
+			// initially empty, gets initialized upon storage connection creation
+			return EmbeddedStorageObjectRegistryCallback.New();
+		}
+
+		protected Reference<PersistenceLiveStorerRegistry> ensureLiveStorerRegistryReference()
+		{
+			throw new MissingFoundationPartException(Reference.class, "to " + PersistenceLiveStorerRegistry.class.getSimpleName());
 		}
 		
 		protected StorageWriteController ensureWriteController()
@@ -221,6 +302,40 @@ extends BinaryPersistenceFoundation<F>
 			}
 			return this.storageRequestAcceptor;
 		}
+		
+		protected PersistenceLiveStorerRegistry ensureLiveStorerRegistry()
+		{
+			// embedded storage must create a functional storer registry for use with the storage layer (GC sweep).
+			return PersistenceLiveStorerRegistry.New();
+		}
+
+		@Override
+		public PersistenceManager<Binary> createPersistenceManager()
+		{
+			final PersistenceLiveStorerRegistry storerRegistry = this.getLiveStorerRegistry();
+			final PersistenceStorer.CreationObserver observer = this.getStorerCreationObserver();
+			if(observer == null)
+			{
+				// registry can simply be set as the (sole) obserber
+				this.setStorerCreationObserver(storerRegistry);
+			}
+			else
+			{
+				// conserve existing observer
+				this.setStorerCreationObserver(
+					PersistenceStorer.CreationObserver.Chain(observer, storerRegistry)
+				);
+			}
+			this.getLiveStorerRegistryReference().set(storerRegistry);
+
+			final PersistenceManager<Binary> pm = super.createPersistenceManager();
+
+			// reference explicitely the PM's object registry, just to be safe
+			this.getObjectRegistryCallback().initializeObjectRegistry(pm.objectRegistry());
+			// note: using more than 1 connection might cause consistency problems for the Storage GC using the callback
+
+			return pm;
+		}
 
 		@Override
 		public synchronized StorageConnection createStorageConnection()
@@ -239,11 +354,11 @@ extends BinaryPersistenceFoundation<F>
 			 */
 			this.internalGetStorageRequestAcceptor();
 
+			// using this. instead of super. is important here!
+			final PersistenceManager<Binary> pm = this.createPersistenceManager();
+
 			// persistence manager is "connected" to the storage's request acceptor (= the storage threads)
-			return StorageConnection.New(
-				super.createPersistenceManager(),
-				this.storageRequestAcceptor
-			);
+			return StorageConnection.New(pm, this.storageRequestAcceptor);
 		}
 
 	}

--- a/storage/embedded/src/main/java/one/microstream/storage/embedded/types/EmbeddedStorageFoundation.java
+++ b/storage/embedded/src/main/java/one/microstream/storage/embedded/types/EmbeddedStorageFoundation.java
@@ -735,7 +735,6 @@ extends StorageFoundation<F>, PersistenceTypeHandlerRegistration.Executor<Binary
 		protected EmbeddedStorageObjectRegistryCallback ensureObjectIdsSelector()
 		{
 			return this.getConnectionFoundation().getObjectRegistryCallback();
-//			return EmbeddedStorageObjectRegistryCallback.New();
 		}
 
 		@Override

--- a/storage/embedded/src/main/java/one/microstream/storage/embedded/types/EmbeddedStorageFoundation.java
+++ b/storage/embedded/src/main/java/one/microstream/storage/embedded/types/EmbeddedStorageFoundation.java
@@ -28,6 +28,7 @@ import org.slf4j.Logger;
 import one.microstream.exceptions.MissingFoundationPartException;
 import one.microstream.persistence.binary.types.Binary;
 import one.microstream.persistence.types.Persistence;
+import one.microstream.persistence.types.PersistenceLiveStorerRegistry;
 import one.microstream.persistence.types.PersistenceObjectIdProvider;
 import one.microstream.persistence.types.PersistenceRefactoringMappingProvider;
 import one.microstream.persistence.types.PersistenceRootResolverProvider;
@@ -38,6 +39,7 @@ import one.microstream.persistence.types.PersistenceTypeHandler;
 import one.microstream.persistence.types.PersistenceTypeHandlerManager;
 import one.microstream.persistence.types.PersistenceTypeHandlerRegistration;
 import one.microstream.persistence.types.PersistenceTypeManager;
+import one.microstream.reference.Reference;
 import one.microstream.storage.types.Database;
 import one.microstream.storage.types.Databases;
 import one.microstream.storage.types.StorageChannelsCreator;
@@ -728,6 +730,13 @@ extends StorageFoundation<F>, PersistenceTypeHandlerRegistration.Executor<Binary
 				}
 			};
 		}
+		
+		@Override
+		protected EmbeddedStorageObjectRegistryCallback ensureObjectIdsSelector()
+		{
+			return this.getConnectionFoundation().getObjectRegistryCallback();
+//			return EmbeddedStorageObjectRegistryCallback.New();
+		}
 
 		@Override
 		public void executeTypeHandlerRegistration(final PersistenceTypeHandlerRegistration<Binary> typeHandlerRegistration)
@@ -764,6 +773,19 @@ extends StorageFoundation<F>, PersistenceTypeHandlerRegistration.Executor<Binary
 		}
 
 		@Override
+		protected Reference<PersistenceLiveStorerRegistry> ensureLiveStorerRegistryReference()
+		{
+			// actual registry reference will get filled in by storage connection creation once that happens
+			return Reference.New(null);
+		}
+
+		@Override
+		public StorageSystem createStorageSystem()
+		{
+			return super.createStorageSystem();
+		}
+		
+		@Override
 		public synchronized EmbeddedStorageManager createEmbeddedStorageManager(final Object root)
 		{
 			logger.info("Creating embedded storage manager");
@@ -771,6 +793,7 @@ extends StorageFoundation<F>, PersistenceTypeHandlerRegistration.Executor<Binary
 			final Database database = this.ensureDatabase();
 
 			final EmbeddedStorageConnectionFoundation<?> ecf = this.getConnectionFoundation();
+			ecf.setLiveStorerRegistryReference(this.getLiveStorerRegistryReference());
 
 			// explicit root must be registered at the rootResolverProvider.
 			if(root != null)
@@ -789,6 +812,9 @@ extends StorageFoundation<F>, PersistenceTypeHandlerRegistration.Executor<Binary
 			final StorageSystem stm = ecf.getStorageSystem();
 
 			initializeTypeDictionary(stm, ecf);
+			
+			// setup callback link from storage to object registry for the GC to check for unexpected live objectIds.
+			this.setLiveObjectIdChecker(ecf.getObjectRegistryCallback());
 
 			// resolve root types to root type ids after types have been initialized
 			this.initializeEmbeddedStorageRootTypeIdProvider(this.getRootTypeIdProvider(), thm);

--- a/storage/embedded/src/main/java/one/microstream/storage/embedded/types/EmbeddedStorageObjectRegistryCallback.java
+++ b/storage/embedded/src/main/java/one/microstream/storage/embedded/types/EmbeddedStorageObjectRegistryCallback.java
@@ -1,5 +1,25 @@
 package one.microstream.storage.embedded.types;
 
+/*-
+ * #%L
+ * MicroStream Embedded Storage
+ * %%
+ * Copyright (C) 2019 - 2022 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is
+ * available at https://www.gnu.org/software/classpath/license.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * #L%
+ */
+
 import one.microstream.persistence.types.ObjectIdsProcessor;
 import one.microstream.persistence.types.ObjectIdsSelector;
 import one.microstream.persistence.types.PersistenceObjectRegistry;

--- a/storage/embedded/src/main/java/one/microstream/storage/embedded/types/EmbeddedStorageObjectRegistryCallback.java
+++ b/storage/embedded/src/main/java/one/microstream/storage/embedded/types/EmbeddedStorageObjectRegistryCallback.java
@@ -1,0 +1,76 @@
+package one.microstream.storage.embedded.types;
+
+import one.microstream.persistence.types.ObjectIdsProcessor;
+import one.microstream.persistence.types.ObjectIdsSelector;
+import one.microstream.persistence.types.PersistenceObjectRegistry;
+
+public interface EmbeddedStorageObjectRegistryCallback extends ObjectIdsSelector
+{
+	public void initializeObjectRegistry(PersistenceObjectRegistry objectRegistry);
+
+
+
+	public static EmbeddedStorageObjectRegistryCallback New()
+	{
+		return new EmbeddedStorageObjectRegistryCallback.Default();
+	}
+
+	public final class Default implements EmbeddedStorageObjectRegistryCallback
+	{
+		///////////////////////////////////////////////////////////////////////////
+		// instance fields //
+		////////////////////
+
+		private PersistenceObjectRegistry objectRegistry;
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// constructors //
+		/////////////////
+
+		Default()
+		{
+			super();
+		}
+
+
+
+		///////////////////////////////////////////////////////////////////////////
+		// methods //
+		////////////
+
+		@Override
+		public synchronized void initializeObjectRegistry(final PersistenceObjectRegistry objectRegistry)
+		{
+			if(this.objectRegistry != null)
+			{
+				if(this.objectRegistry == objectRegistry)
+				{
+					return;
+				}
+
+				// (29.07.2022 TM)EXCP: proper exception
+				throw new RuntimeException("ObjectRegistry already initialized.");
+			}
+
+			this.objectRegistry = objectRegistry;
+		}
+
+		@Override
+		public synchronized void processSelected(final ObjectIdsProcessor processor)
+		{
+			if(this.objectRegistry == null)
+			{
+				// object registry not yet initialized (i.e. no application-side storage connection yet)
+				processor.processObjectIdsByFilter(objectId -> false);
+				return;
+			}
+
+			// efficient for embedded mode, but servermode should use #selectLiveObjectIds instead.
+			this.objectRegistry.processLiveObjectIds(processor);
+		}
+
+	}
+
+}

--- a/storage/embedded/src/main/java/one/microstream/storage/embedded/types/EmbeddedStorageObjectRegistryCallback.java
+++ b/storage/embedded/src/main/java/one/microstream/storage/embedded/types/EmbeddedStorageObjectRegistryCallback.java
@@ -58,17 +58,17 @@ public interface EmbeddedStorageObjectRegistryCallback extends ObjectIdsSelector
 		}
 
 		@Override
-		public synchronized void processSelected(final ObjectIdsProcessor processor)
+		public synchronized boolean processSelected(final ObjectIdsProcessor processor)
 		{
 			if(this.objectRegistry == null)
 			{
 				// object registry not yet initialized (i.e. no application-side storage connection yet)
 				processor.processObjectIdsByFilter(objectId -> false);
-				return;
+				return true;
 			}
 
 			// efficient for embedded mode, but servermode should use #selectLiveObjectIds instead.
-			this.objectRegistry.processLiveObjectIds(processor);
+			return this.objectRegistry.processLiveObjectIds(processor);
 		}
 
 	}

--- a/storage/rest/adapter/src/main/java/one/microstream/storage/restadapter/types/ViewerObjectRegistryDisabled.java
+++ b/storage/rest/adapter/src/main/java/one/microstream/storage/restadapter/types/ViewerObjectRegistryDisabled.java
@@ -1,5 +1,7 @@
 package one.microstream.storage.restadapter.types;
 
+import one.microstream.collections.Set_long;
+
 /*-
  * #%L
  * microstream-storage-restadapter
@@ -22,6 +24,7 @@ package one.microstream.storage.restadapter.types;
 
 import one.microstream.collections.types.XGettingTable;
 import one.microstream.hashing.HashStatistics;
+import one.microstream.persistence.types.ObjectIdsProcessor;
 import one.microstream.persistence.types.PersistenceAcceptor;
 import one.microstream.persistence.types.PersistenceObjectRegistry;
 
@@ -199,6 +202,20 @@ public class ViewerObjectRegistryDisabled implements PersistenceObjectRegistry
 	public void validate(final long objectId, final Object object)
 	{
 		// no-op
+	}
+	
+	@Override
+	public <P extends ObjectIdsProcessor> P processLiveObjectIds(final P processor)
+	{
+		// no-op
+		return processor;
+	}
+
+	@Override
+	public Set_long selectLiveObjectIds(final Set_long objectIdsBaseSet)
+	{
+		// no-op
+		return objectIdsBaseSet;
 	}
 
 }

--- a/storage/rest/adapter/src/main/java/one/microstream/storage/restadapter/types/ViewerObjectRegistryDisabled.java
+++ b/storage/rest/adapter/src/main/java/one/microstream/storage/restadapter/types/ViewerObjectRegistryDisabled.java
@@ -205,10 +205,10 @@ public class ViewerObjectRegistryDisabled implements PersistenceObjectRegistry
 	}
 	
 	@Override
-	public <P extends ObjectIdsProcessor> P processLiveObjectIds(final P processor)
+	public synchronized boolean processLiveObjectIds(final ObjectIdsProcessor processor)
 	{
 		// no-op
-		return processor;
+		return true;
 	}
 
 	@Override

--- a/storage/storage/src/main/java/one/microstream/storage/types/StorageChannelsCreator.java
+++ b/storage/storage/src/main/java/one/microstream/storage/types/StorageChannelsCreator.java
@@ -21,34 +21,39 @@ package one.microstream.storage.types;
  */
 
 import one.microstream.memory.XMemory;
+import one.microstream.persistence.types.ObjectIdsSelector;
+import one.microstream.persistence.types.PersistenceLiveStorerRegistry;
+import one.microstream.reference.Referencing;
 import one.microstream.util.BufferSizeProvider;
 import one.microstream.util.BufferSizeProviderIncremental;
 
 public interface StorageChannelsCreator
 {
 	public StorageChannel[] createChannels(
-		int                                  channelCount                 ,
-		StorageInitialDataFileNumberProvider initialDataFileNumberProvider,
-		StorageExceptionHandler              exceptionHandler             ,
-		StorageDataFileEvaluator             fileDissolver                ,
-		StorageLiveFileProvider              liveFileProvider             ,
-		StorageEntityCacheEvaluator          entityCacheEvaluator         ,
-		StorageTypeDictionary                typeDictionary               ,
-		StorageTaskBroker                    taskBroker                   ,
-		StorageOperationController           operationController          ,
-		StorageHousekeepingBroker            housekeepingBroker           ,
-		StorageHousekeepingController        housekeepingController       ,
-		StorageTimestampProvider             timestampProvider            ,
-		StorageWriteController               writeController              ,
-		StorageFileWriter.Provider           writerProvider               ,
-		StorageGCZombieOidHandler            zombieOidHandler             ,
-		StorageRootOidSelector.Provider      rootOidSelectorProvider      ,
-		StorageObjectIdMarkQueue.Creator     oidMarkQueueCreator          ,
-		StorageEntityMarkMonitor.Creator     entityMarkMonitorCreator     ,
-		StorageBackupHandler                 backupHandler                ,
-		StorageEventLogger                   eventLogger                  ,
-		boolean                              switchByteOrder              ,
-		long                                 rootTypeId
+		int                                        channelCount                 ,
+		StorageInitialDataFileNumberProvider       initialDataFileNumberProvider,
+		StorageExceptionHandler                    exceptionHandler             ,
+		StorageDataFileEvaluator                   fileDissolver                ,
+		StorageLiveFileProvider                    liveFileProvider             ,
+		StorageEntityCacheEvaluator                entityCacheEvaluator         ,
+		StorageTypeDictionary                      typeDictionary               ,
+		StorageTaskBroker                          taskBroker                   ,
+		StorageOperationController                 operationController          ,
+		StorageHousekeepingBroker                  housekeepingBroker           ,
+		StorageHousekeepingController              housekeepingController       ,
+		StorageTimestampProvider                   timestampProvider            ,
+		StorageWriteController                     writeController              ,
+		StorageFileWriter.Provider                 writerProvider               ,
+		StorageGCZombieOidHandler                  zombieOidHandler             ,
+		StorageRootOidSelector.Provider            rootOidSelectorProvider      ,
+		StorageObjectIdMarkQueue.Creator           oidMarkQueueCreator          ,
+		StorageEntityMarkMonitor.Creator           entityMarkMonitorCreator     ,
+		StorageBackupHandler                       backupHandler                ,
+		StorageEventLogger                         eventLogger                  ,
+		ObjectIdsSelector                          liveObjectIdChecker          ,
+		Referencing<PersistenceLiveStorerRegistry> refStorerRegistry            ,
+		boolean                                    switchByteOrder              ,
+		long                                       rootTypeId
 	);
 
 
@@ -61,28 +66,30 @@ public interface StorageChannelsCreator
 
 		@Override
 		public final StorageChannel.Default[] createChannels(
-			final int                                  channelCount                 ,
-			final StorageInitialDataFileNumberProvider initialDataFileNumberProvider,
-			final StorageExceptionHandler              exceptionHandler             ,
-			final StorageDataFileEvaluator             dataFileEvaluator            ,
-			final StorageLiveFileProvider              liveFileProvider             ,
-			final StorageEntityCacheEvaluator          entityCacheEvaluator         ,
-			final StorageTypeDictionary                typeDictionary               ,
-			final StorageTaskBroker                    taskBroker                   ,
-			final StorageOperationController           operationController          ,
-			final StorageHousekeepingBroker            housekeepingBroker           ,
-			final StorageHousekeepingController        housekeepingController       ,
-			final StorageTimestampProvider             timestampProvider            ,
-			final StorageWriteController               writeController              ,
-			final StorageFileWriter.Provider           writerProvider               ,
-			final StorageGCZombieOidHandler            zombieOidHandler             ,
-			final StorageRootOidSelector.Provider      rootOidSelectorProvider      ,
-			final StorageObjectIdMarkQueue.Creator     oidMarkQueueCreator          ,
-			final StorageEntityMarkMonitor.Creator     entityMarkMonitorCreator     ,
-			final StorageBackupHandler                 backupHandler                ,
-			final StorageEventLogger                   eventLogger                  ,
-			final boolean                              switchByteOrder              ,
-			final long                                 rootTypeId
+			final int                                        channelCount                 ,
+			final StorageInitialDataFileNumberProvider       initialDataFileNumberProvider,
+			final StorageExceptionHandler                    exceptionHandler             ,
+			final StorageDataFileEvaluator                   dataFileEvaluator            ,
+			final StorageLiveFileProvider                    liveFileProvider             ,
+			final StorageEntityCacheEvaluator                entityCacheEvaluator         ,
+			final StorageTypeDictionary                      typeDictionary               ,
+			final StorageTaskBroker                          taskBroker                   ,
+			final StorageOperationController                 operationController          ,
+			final StorageHousekeepingBroker                  housekeepingBroker           ,
+			final StorageHousekeepingController              housekeepingController       ,
+			final StorageTimestampProvider                   timestampProvider            ,
+			final StorageWriteController                     writeController              ,
+			final StorageFileWriter.Provider                 writerProvider               ,
+			final StorageGCZombieOidHandler                  zombieOidHandler             ,
+			final StorageRootOidSelector.Provider            rootOidSelectorProvider      ,
+			final StorageObjectIdMarkQueue.Creator           oidMarkQueueCreator          ,
+			final StorageEntityMarkMonitor.Creator           entityMarkMonitorCreator     ,
+			final StorageBackupHandler                       backupHandler                ,
+			final StorageEventLogger                         eventLogger                  ,
+			final ObjectIdsSelector                          liveObjectIdChecker          ,
+			final Referencing<PersistenceLiveStorerRegistry> refStorerRegistry            ,
+			final boolean                                    switchByteOrder              ,
+			final long                                       rootTypeId
 		)
 		{
 			// (14.07.2016 TM)TODO: make configuration dynamic
@@ -100,7 +107,8 @@ public interface StorageChannelsCreator
 			}
 			final StorageEntityMarkMonitor markMonitor = entityMarkMonitorCreator.createEntityMarkMonitor(
 				markQueues,
-				eventLogger
+				eventLogger,
+				refStorerRegistry
 			);
 			
 			final BufferSizeProviderIncremental loadingBufferSizeProvider = BufferSizeProviderIncremental.New(loadingBufferSize);
@@ -120,6 +128,7 @@ public interface StorageChannelsCreator
 					rootTypeId                                       ,
 					markQueues[i]                                    ,
 					eventLogger                                      ,
+					liveObjectIdChecker                              ,
 					markingWaitTimeMs                                ,
 					markBufferLength
 				);

--- a/storage/storage/src/main/java/one/microstream/storage/types/StorageEntityCache.java
+++ b/storage/storage/src/main/java/one/microstream/storage/types/StorageEntityCache.java
@@ -31,11 +31,15 @@ import org.slf4j.Logger;
 
 import one.microstream.X;
 import one.microstream.collections.EqHashEnum;
+import one.microstream.collections.Set_long;
 import one.microstream.functional.ThrowingProcedure;
+import one.microstream.functional._longPredicate;
 import one.microstream.math.XMath;
 import one.microstream.memory.XMemory;
 import one.microstream.persistence.binary.types.Binary;
 import one.microstream.persistence.binary.types.ChunksBuffer;
+import one.microstream.persistence.types.ObjectIdsProcessor;
+import one.microstream.persistence.types.ObjectIdsSelector;
 import one.microstream.persistence.types.Persistence;
 import one.microstream.persistence.types.Unpersistable;
 import one.microstream.storage.exceptions.StorageException;
@@ -126,6 +130,8 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 		private final StorageEntityMarkMonitor  markMonitor    ;
 		private final StorageObjectIdMarkQueue  oidMarkQueue   ; // resetting handled by markMonitor
 		private final StorageReferenceMarker    referenceMarker; // resetting must be handled here.
+		
+		private final ObjectIdsSelector liveObjectIdChecker;
 
 		
 		// state 3.0: mutable fields. Must be cleared on reset.
@@ -170,6 +176,7 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 			final long                        rootTypeId         ,
 			final StorageObjectIdMarkQueue    oidMarkQueue       ,
 			final StorageEventLogger          eventLogger        ,
+			final ObjectIdsSelector           liveObjectIdChecker,
 			final long                        markingWaitTimeMs  ,
 			final int                         markingBufferLength
 		)
@@ -199,6 +206,8 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 			
 			// create reference marker at the very end to have all state properly initialized beforehand.
 			this.referenceMarker = markMonitor.provideReferenceMarker(this);
+			
+			this.liveObjectIdChecker = notNull(liveObjectIdChecker);
 		}
 
 
@@ -996,7 +1005,15 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 			return false;
 		}
 
-		private void sweep()
+		/**
+		 * If an entity (its OID) is still reachable in the application, it may not be deleted.
+		 * Otherwise, data might be lost since the entity still exists for the application and thus
+		 * is only stored by reference but not in full. The passed predicate is a connection to the
+		 * application's object registry to perform the required check.
+		 * 
+		 * @param isReachableInApplication
+		 */
+		final void sweep(final _longPredicate isReachableInApplication)
 		{
 			this.lastSweepStart = System.currentTimeMillis();
 			final StorageEntityType.Default typeHead = this.typeHead;
@@ -1007,7 +1024,7 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 				for(StorageEntity.Default item, last = sweepType.head; (item = last.typeNext) != null;)
 				{
 					// actual sweep: white entities are deleted, non-white entities are marked white but not deleted
-					if(item.isGcMarked())
+					if(item.isGcMarked() || isReachableInApplication.test(item.objectId))
 					{
 						// reset to white and advance one item
 						(last = item).markWhite();
@@ -1030,6 +1047,51 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 			final long channelRootOid = this.queryRootObjectId();
 			this.markMonitor.completeSweep(this, this.rootOidSelector, channelRootOid);
 		}
+		
+		private void sweep()
+		{
+			this.liveObjectIdChecker.processSelected(new ApplicationCallback(this.typeHead));
+		}
+
+		final class ApplicationCallback implements ObjectIdsProcessor
+		{
+			final StorageEntityType.Default typeHead;
+
+			ApplicationCallback(final StorageEntityType.Default typeHead)
+			{
+				super();
+				this.typeHead = typeHead;
+			}
+
+			@Override
+			public void processObjectIdsByFilter(final _longPredicate objectIdsSelector)
+			{
+				Default.this.sweep(objectIdsSelector);
+			}
+
+			@Override
+			public Set_long provideObjectIdsBaseSet()
+			{
+				final Set_long sweepCandicateObjectIds = Set_long.New(1000);
+
+				final StorageEntityType.Default typeHead = this.typeHead;
+				for(StorageEntityType.Default sweepType = typeHead; (sweepType = sweepType.next) != typeHead;)
+				{
+					// get next item and check for end of type (switch to next type required)
+					for(StorageEntity.Default item = sweepType.head; (item = item.typeNext) != null;)
+					{
+						if(!item.isGcMarked())
+						{
+							sweepCandicateObjectIds.add(item.objectId);
+						}
+					}
+				}
+
+				return sweepCandicateObjectIds;
+			}
+
+		}
+		
 
 		private static final long MAX_INT_BOUND = 1L + Integer.MAX_VALUE;
 		

--- a/storage/storage/src/main/java/one/microstream/storage/types/StorageEntityCache.java
+++ b/storage/storage/src/main/java/one/microstream/storage/types/StorageEntityCache.java
@@ -1048,9 +1048,9 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 			this.markMonitor.completeSweep(this, this.rootOidSelector, channelRootOid);
 		}
 		
-		private void sweep()
+		private boolean sweep()
 		{
-			this.liveObjectIdChecker.processSelected(new ApplicationCallback(this.typeHead));
+			return this.liveObjectIdChecker.processSelected(new ApplicationCallback(this.typeHead));
 		}
 
 		final class ApplicationCallback implements ObjectIdsProcessor
@@ -1555,7 +1555,11 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 			// check if there is sweeping to be done
 			if(this.markMonitor.needsSweep(this))
 			{
-				this.sweep();
+				if(!this.sweep())
+				{
+					// sweep aborted due to locked object registry. Retry on next attempt.
+					return false;
+				}
 
 				// must check for completion again, otherwise a channel might restart marking beyond a completed gc.
 				if(this.checkForGcCompletion())

--- a/storage/storage/src/main/java/one/microstream/storage/types/StorageEntityCache.java
+++ b/storage/storage/src/main/java/one/microstream/storage/types/StorageEntityCache.java
@@ -1568,12 +1568,10 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 				 */
 
 				// work ran out
-				System.out.println("Mark finished");
 				return true;
 			}
 
 			// time ran out
-			System.out.println("Mark unfinished");
 			return false;
 		}
 

--- a/storage/storage/src/main/java/one/microstream/storage/types/StorageEntityCache.java
+++ b/storage/storage/src/main/java/one/microstream/storage/types/StorageEntityCache.java
@@ -79,27 +79,12 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 	{
 		private final static Logger logger = Logging.getLogger(Default.class);
 		
-		// (24.11.2017 TM)TODO: there seems to still be a GC race condition bug, albeit only very rarely.
-		private static boolean experimentalGcEnabled = false;
 		
-		/**
-		 * <b><u>/!\ EXPERIMENTAL /!\</u></b> Storage-level garbage collection is an unfinished feature with a still tiny race condition problem
-		 * that can cause the database to be ruined occasionally.
-		 * <p>
-		 * <b>Enable at your own risk!</b>
-		 * <p>
-		 * Also note that this method is a temporary experimental function for debugging purposes
-		 * and can disappear at any release.<br>
-		 * <b>Do not use this is production mode.</b>
-		 * 
-		 * @param enabled <code>true</code> if the gc should be enabled, <code>false</code> otherwise
-		 * 
-		 * @deprecated experimental
-		 */
-		@Deprecated
+		private static boolean gcEnabled = true;
+				
 		public static void setGarbageCollectionEnabled(final boolean enabled)
 		{
-			experimentalGcEnabled = enabled;
+			gcEnabled = enabled;
 		}
 		
 		
@@ -1428,7 +1413,7 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 			final StorageChannel channel
 		)
 		{
-			if(!experimentalGcEnabled)
+			if(!gcEnabled)
 			{
 				return true;
 			}
@@ -1513,7 +1498,7 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 			final StorageChannel channel
 		)
 		{
-			if(!experimentalGcEnabled)
+			if(!gcEnabled)
 			{
 				return true;
 			}
@@ -1583,10 +1568,12 @@ public interface StorageEntityCache<E extends StorageEntity> extends StorageChan
 				 */
 
 				// work ran out
+				System.out.println("Mark finished");
 				return true;
 			}
 
 			// time ran out
+			System.out.println("Mark unfinished");
 			return false;
 		}
 


### PR DESCRIPTION
Add live object check to GC. Ensures retaining of objects in storage when still live in VM. Additional regression concurrency fix.
Finally fixes all remaining GC issues, brings it out of the experimental stage and activates it by default.