### PR TITLE
closing file after deleting

### DIFF
--- a/afs/afs/src/main/java/one/microstream/afs/types/AIoHandler.java
+++ b/afs/afs/src/main/java/one/microstream/afs/types/AIoHandler.java
@@ -167,7 +167,7 @@ public interface AIoHandler extends WriteController
 	
 	public XGettingEnum<String> listFiles(ADirectory parent);
 		
-	public boolean isEmpty(ADirectory directory);	
+	public boolean isEmpty(ADirectory directory);
 	
 	
 	public abstract class Abstract<
@@ -613,7 +613,7 @@ public interface AIoHandler extends WriteController
 		}
 		
 		@Override
-		public boolean isEmpty(final ADirectory directory) 
+		public boolean isEmpty(final ADirectory directory)
 		{
 			this.validateHandledDirectory(directory);
 			
@@ -1253,6 +1253,10 @@ public interface AIoHandler extends WriteController
 					);
 					
 					result = this.specificDeleteFile(this.typeWritableFile.cast(file));
+					if(result)
+					{
+						file.close();
+					}
 			
 					file.iterateObservers(o ->
 						o.onAfterFileDelete(file, result)


### PR DESCRIPTION
When deleting a StorageFile its delete method ensures that the StorageFile is writable. The ensureWritable method internally opens a FileChannel if the NIO AFS is used. That FileChannel is not closed after deleting the file (in the app). The open file channel may pevent the OS from deleting the file and releasing disk space.