### PR TITLE
spring - generate metadata for configuration properties 

### DIFF
--- a/integrations/spring-boot/pom.xml
+++ b/integrations/spring-boot/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <!-- minimal version is 2.1.0.RELEASE -->
-        <org.springframework.boot.version>2.6.7</org.springframework.boot.version>
+        <org.springframework.boot.version>2.7.3</org.springframework.boot.version>
     </properties>
 
 
@@ -87,6 +87,28 @@
                 <configuration>
                     <skip>true</skip>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
+                <configuration>
+                    <compilerId>javac</compilerId>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>process-annotations</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>-proc:only</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
change compiler to javac for a Spring project. I was not able to run the annotation processor under the eclipse compiler. 

And update spring version - old has a CVE.