### PR TITLE
Better readable log value

### DIFF
--- a/storage/storage/src/main/java/one/microstream/storage/types/StorageHousekeepingController.java
+++ b/storage/storage/src/main/java/one/microstream/storage/types/StorageHousekeepingController.java
@@ -451,7 +451,7 @@ public interface StorageHousekeepingController
 				this.maximumNs,
 				increaseNs
 			);
-			logger.debug("New adaptive housekeeping increase: {} ns", this.currentIncreaseNs);
+			logger.debug("New adaptive housekeeping increase: {} ns", String.format("%,d", this.currentIncreaseNs));
 		}
 
 		@Override


### PR DESCRIPTION
Just to add better readable value in log. I have problem to read if the value has ben 5 or 50 seconds in ns format. 
Now 50000000 ns is in log in format 50 000 000 ns
<img width="487" alt="image" src="https://user-images.githubusercontent.com/17253582/189041685-923842e0-1d8f-4875-b4dc-c08b4b8e260c.png">
