### PR TITLE
Bug/throw exception on enum ordinal change

### DIFF
--- a/persistence/persistence/src/main/java/one/microstream/persistence/exceptions/PersistenceExceptionTypeConsistencyEnum.java
+++ b/persistence/persistence/src/main/java/one/microstream/persistence/exceptions/PersistenceExceptionTypeConsistencyEnum.java
@@ -1,5 +1,25 @@
 package one.microstream.persistence.exceptions;
 
+/*-
+ * #%L
+ * MicroStream Persistence
+ * %%
+ * Copyright (C) 2019 - 2022 MicroStream Software
+ * %%
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License, v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is
+ * available at https://www.gnu.org/software/classpath/license.html.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * #L%
+ */
+
 public class PersistenceExceptionTypeConsistencyEnum extends PersistenceExceptionConsistency
 {
 	///////////////////////////////////////////////////////////////////////////

--- a/persistence/persistence/src/main/java/one/microstream/persistence/exceptions/PersistenceExceptionTypeConsistencyEnum.java
+++ b/persistence/persistence/src/main/java/one/microstream/persistence/exceptions/PersistenceExceptionTypeConsistencyEnum.java
@@ -1,0 +1,29 @@
+package one.microstream.persistence.exceptions;
+
+public class PersistenceExceptionTypeConsistencyEnum extends PersistenceExceptionConsistency
+{
+	///////////////////////////////////////////////////////////////////////////
+	// constructors //
+	/////////////////
+	
+	public PersistenceExceptionTypeConsistencyEnum(final String constantName, final String enumClassName, final int ordinal, final long targetOrdinal)
+	{
+		super(
+			buildMessage(
+				constantName,
+				enumClassName,
+				ordinal,
+				targetOrdinal
+		));
+	}
+	
+	private static String buildMessage(final String constantName, final String enumClassName, final int ordinal, final long targetOrdinal)
+	{
+		return "The ordinal of the enum constant " + constantName + " of " +
+			enumClassName +
+			"\nwould be change by the legacy type mapping from " +
+			ordinal + " to " + targetOrdinal + ". This may cause the storage becoming corrupted." +
+			"\nIf the ordinal change is intended you need to define a manual legacy type mapping!";
+	}
+}
+	

--- a/persistence/persistence/src/main/java/one/microstream/persistence/types/PersistenceLegacyTypeHandlerCreator.java
+++ b/persistence/persistence/src/main/java/one/microstream/persistence/types/PersistenceLegacyTypeHandlerCreator.java
@@ -1,12 +1,8 @@
 package one.microstream.persistence.types;
 
-import org.slf4j.Logger;
-
-import one.microstream.chars.XChars;
-
 /*-
  * #%L
- * microstream-persistence
+ * MicroStream Persistence
  * %%
  * Copyright (C) 2019 - 2022 MicroStream Software
  * %%
@@ -24,6 +20,9 @@ import one.microstream.chars.XChars;
  * #L%
  */
 
+import org.slf4j.Logger;
+
+import one.microstream.chars.XChars;
 import one.microstream.collections.BulkList;
 import one.microstream.persistence.exceptions.PersistenceException;
 import one.microstream.persistence.exceptions.PersistenceExceptionTypeConsistencyEnum;

--- a/persistence/persistence/src/main/java/one/microstream/persistence/types/PersistenceLegacyTypeHandlerCreator.java
+++ b/persistence/persistence/src/main/java/one/microstream/persistence/types/PersistenceLegacyTypeHandlerCreator.java
@@ -26,6 +26,7 @@ import one.microstream.chars.XChars;
 
 import one.microstream.collections.BulkList;
 import one.microstream.persistence.exceptions.PersistenceException;
+import one.microstream.persistence.exceptions.PersistenceExceptionTypeConsistencyEnum;
 import one.microstream.reflect.XReflect;
 import one.microstream.util.logging.Logging;
 import one.microstream.util.similarity.Similarity;
@@ -83,8 +84,22 @@ public interface PersistenceLegacyTypeHandlerCreator<D>
 				{
 					final PersistenceTypeDefinitionMember targetCurrentConstant = match.targetElement();
 					final long targetOrdinal = currentConstantMembers.indexOf(targetCurrentConstant);
+						
 					if(targetOrdinal >= 0)
 					{
+						if(targetOrdinal != ordinal)
+						{
+							if(match.similarity() != PersistenceLegacyTypeMapper.Defaults.defaultExplicitMappingSimilarity())
+							{
+								throw new PersistenceExceptionTypeConsistencyEnum(
+									targetCurrentConstant.identifier(),
+									result.currentTypeHandler().typeName(),
+									ordinal,
+									targetOrdinal
+								);
+							}
+						}
+								
 						ordinalMap[ordinal] = Integer.valueOf((int)targetOrdinal);
 					}
 					else

--- a/persistence/persistence/src/main/java/one/microstream/persistence/types/PersistenceLegacyTypeHandlerCreator.java
+++ b/persistence/persistence/src/main/java/one/microstream/persistence/types/PersistenceLegacyTypeHandlerCreator.java
@@ -87,6 +87,7 @@ public interface PersistenceLegacyTypeHandlerCreator<D>
 						
 					if(targetOrdinal >= 0)
 					{
+						//allow ordinal changes only by explicit manual mappings
 						if(targetOrdinal != ordinal)
 						{
 							if(match.similarity() != PersistenceLegacyTypeMapper.Defaults.defaultExplicitMappingSimilarity())


### PR DESCRIPTION
Prevent storage corruption as described in #381 and #432 by throwing an exception in case of enum ordianl changes by automatic legacy type mappings.