### PR TITLE
Remove unsupported Helidon Maven plugins for version 2.4+

### DIFF
--- a/examples/helidon-mp/pom.xml
+++ b/examples/helidon-mp/pom.xml
@@ -107,16 +107,6 @@
 						</configuration>
 					</plugin>
 					<plugin>
-						<groupId>io.helidon.build-tools</groupId>
-						<artifactId>helidon-maven-plugin</artifactId>
-						<version>${helidon.version}</version>
-					</plugin>
-					<plugin>
-						<groupId>io.helidon.build-tools</groupId>
-						<artifactId>helidon-cli-maven-plugin</artifactId>
-						<version>${helidon.version}</version>
-					</plugin>
-					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-dependency-plugin</artifactId>
 						<executions>


### PR DESCRIPTION
To address Maven warnings.

These plugins are not needed for compiling and running our example on JDK.

https://github.com/microstream-one/microstream/pull/444#issuecomment-1307179962