### PR TITLE
fix to make the build compliant with maven 4

### DIFF
--- a/examples/helidon-mp/pom.xml
+++ b/examples/helidon-mp/pom.xml
@@ -123,7 +123,7 @@
 									<overWriteIfNewer>true</overWriteIfNewer>
 									<overWriteIfNewer>true</overWriteIfNewer>
 									<includeScope>runtime</includeScope>
-									<excludeScope>test</excludeScope>
+									<excludeScope>compile</excludeScope>
 								</configuration>
 							</execution>
 						</executions>


### PR DESCRIPTION
Hi @rdebusscher can you take a look at this. 

> Failed to execute goal org.apache.maven.plugins:maven-dependency-plugin:3.3.0:copy-dependencies (copy-libs) on project microstream-examples-helidon-mp: Excluding every artifact inside 'test' resolution scope means excluding everything: you probably want includeScope='compile', read parameters documentation for detailed explanations