### PR TITLE
fix intlist - nullAllowed + copyArrayToDestination

### DIFF
--- a/base/src/main/java/one/microstream/collections/Abstract_intArrayStorage.java
+++ b/base/src/main/java/one/microstream/collections/Abstract_intArrayStorage.java
@@ -710,38 +710,33 @@ public abstract class Abstract_intArrayStorage
 		final int targetOffset
 	)
 	{
-		final int endIndex;
 		if(length >= 0)
 		{
 			if(length == 0)
 			{
 				return target;
 			}
-			System.arraycopy(data, offset, target, offset, length);
+			System.arraycopy(data, offset, target, targetOffset, length);
 			return target;
-		}
-		else if(length < 0)
-		{
-			if((endIndex = offset + length + 1) < 0 || offset >= size)
-			{
-				throw new IndexOutOfBoundsException(exceptionRange(size, offset, length));
-			}
-		}
-		else if(offset < 0 || offset >= size)
-		{
-			throw new IndexOutOfBoundsException(exceptionIndexOutOfBounds(size, offset));
 		}
 		else
 		{
-			// handle length 0 special case not as escape condition but as last case to ensure index checking
+			final int endIndex= offset + length + 1;
+			if(endIndex  < 0)
+			{
+				throw new IndexOutOfBoundsException(exceptionRange(size, offset, length));
+			}
+			else if(offset < 0 || offset >= size)
+			{
+				throw new IndexOutOfBoundsException(exceptionIndexOutOfBounds(size, offset));
+			}
+
+			for(int i = offset, t = targetOffset; i >= endIndex; i--)
+			{
+				target[t++] = data[i];
+			}
 			return target;
 		}
-
-		for(int i = offset, t = targetOffset; i >= endIndex; i--)
-		{
-			target[t++] = data[i];
-		}
-		return target;
 	}
 
 	public static final <C extends _intCollecting> C copySelection(

--- a/base/src/main/java/one/microstream/collections/_intList.java
+++ b/base/src/main/java/one/microstream/collections/_intList.java
@@ -622,7 +622,7 @@ public final class _intList implements _intCollecting, Composition
 
 	public boolean nullAllowed()
 	{
-		return true;
+		return false;
 	}
 
 	public boolean isSorted(final boolean ascending)


### PR DESCRIPTION
_IntList contains only arrays with the primitive type int. Which by principle cannot be null. Thus, nullAllowed must return false because it is not possible to insert null into this data type. 
No less this function is not called anywhere. 

Second commit is fix method to copy some array to another array. 