### PR TITLE
Missing S3 config properties through Spring configuration.

### DIFF
--- a/integrations/spring-boot/src/main/java/one/microstream/integrations/spring/boot/types/aws/Aws.java
+++ b/integrations/spring-boot/src/main/java/one/microstream/integrations/spring/boot/types/aws/Aws.java
@@ -4,7 +4,7 @@ package one.microstream.integrations.spring.boot.types.aws;
  * #%L
  * microstream-spring
  * %%
- * Copyright (C) 2019 - 2022 MicroStream Software
+ * Copyright (C) 2019 - 2023 MicroStream Software
  * %%
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -28,13 +28,26 @@ public class Aws
     @NestedConfigurationProperty
     private Dynamodb dynamodb;
 
+    @NestedConfigurationProperty
+    private S3 s3;
+
     public Dynamodb getDynamodb()
     {
-        return dynamodb;
+        return this.dynamodb;
     }
 
-    public void setDynamodb(Dynamodb dynamodb)
+    public void setDynamodb(final Dynamodb dynamodb)
     {
         this.dynamodb = dynamodb;
+    }
+
+    public S3 getS3()
+    {
+        return this.s3;
+    }
+
+    public void setS3(final S3 s3)
+    {
+        this.s3 = s3;
     }
 }


### PR DESCRIPTION
Currently, a config like specified in the doc isn't picked up due to missing `S3` in `Aws` class.

```
storage-filesystem.aws.s3.credentials.type=static
storage-filesystem.aws.s3.credentials.access-key-id=my-access-key-id
storage-filesystem.aws.s3.credentials.secret-acces-key=my-secret-access-key
storage-filesystem.aws.s3.credentials.region=us-east-1
```

example from https://docs.microstream.one/manual/storage/storage-targets/blob-stores/aws-s3.html#_configuration