### PR TITLE
Set appropriate `ClassLoaderProvider` in Spring Boot integrations

### DIFF
--- a/docs/modules/misc/pages/integrations/spring-boot.adoc
+++ b/docs/modules/misc/pages/integrations/spring-boot.adoc
@@ -190,13 +190,3 @@ to obtain all MicroStream configuration keys:
 ----
 
 Key values containing "password" are replaced by "xxxxx".
-
-== Classloader configuration
-
-If you use another class loader, such as hot replace, you may get an exception:
-`one.microstream.exceptions.TypeCastException`<br>
-In this case, it is possible to force the use of the current thread's class loader for MicroStream.<br>
-`one.microstream.use-current-thread-class-loader=false` <br>
-This value is not passed to the MicroStream framework but is set directly in this module.
-
-This configuration is only applied to the _StorageManager_ Spring bean and not to the _EmbeddedStorageFoundation_ Spring bean.

--- a/integrations/spring-boot/README.md
+++ b/integrations/spring-boot/README.md
@@ -81,14 +81,6 @@ In that case, the configuration keys that you need to use are `one.microstream.`
 This framework forwards all configuration keys to MicroStream. It is important to follow the format that the
 MicroStream framework needs regardless of what the Spring configuration framework allows.
 
-### Class Loader
-
-Spring Boot class loader. If you use another class loader, such as hot replace, you may get an exception:
-`one.microstream.exceptions.TypeCastException`<br>
-In this case it is possible to force the use of the current thread's class loader for MicroStream.<br>
-`one.microstream.use-current-thread-class-loader=true` <br>
-This value is not passed to the MicroStream framework but is set directly in this module.
-
 ## Debug
 
 MicroStream Spring module supports standard Spring logging, so you can add into your config:<br>

--- a/integrations/spring-boot/src/it/postgres-config/src/main/resources/application.properties
+++ b/integrations/spring-boot/src/it/postgres-config/src/main/resources/application.properties
@@ -4,4 +4,3 @@ one.microstream.storage-filesystem.sql.postgres.data-source-provider=test.micros
 one.microstream.storage-filesystem.sql.postgres.password=password1
 one.microstream.storage-filesystem.sql.postgres.user=postgres
 one.microstream.storage-directory=microstream_storage
-one.microstream.use-current-thread-class-loader=false

--- a/integrations/spring-boot/src/main/java/module-info.java
+++ b/integrations/spring-boot/src/main/java/module-info.java
@@ -31,6 +31,7 @@ module microstream.integrations.spring.boot
 	exports one.microstream.integrations.spring.boot.types.oracle.nosql;
 	exports one.microstream.integrations.spring.boot.types.oraclecloud;
 	exports one.microstream.integrations.spring.boot.types.config;
+	exports one.microstream.integrations.spring.boot.types.storage;
 
 	requires transitive microstream.storage.embedded.configuration;
 	requires transitive spring.beans;

--- a/integrations/spring-boot/src/main/java/one/microstream/integrations/spring/boot/types/MultipleStorageBeanException.java
+++ b/integrations/spring-boot/src/main/java/one/microstream/integrations/spring/boot/types/MultipleStorageBeanException.java
@@ -28,13 +28,13 @@ import java.util.stream.Collectors;
 
 public class MultipleStorageBeanException extends BeansException
 {
-    public MultipleStorageBeanException(final Map<String, List<Class>> classes)
+    public MultipleStorageBeanException(final Map<String, ? extends List<? extends Class<?>>> classes)
     {
         super(String.format("Multiple beans are annotated with @Storage and the same qualifier: %s",
                             defineInfo(classes)));
     }
 
-    private static String defineInfo(final Map<String, List<Class>> classes)
+    private static String defineInfo(final Map<String, ? extends List<? extends Class<?>>> classes)
     {
         return classes.entrySet()
                 .stream()
@@ -42,7 +42,7 @@ public class MultipleStorageBeanException extends BeansException
                 .collect(Collectors.joining(" / "));
     }
 
-    private static String listClassNames(List<Class> classes)
+    private static String listClassNames(List<? extends Class<?>> classes)
     {
         return classes.stream()
                 .map(Class::getName)

--- a/integrations/spring-boot/src/main/java/one/microstream/integrations/spring/boot/types/config/MicrostreamConfigurationProperties.java
+++ b/integrations/spring-boot/src/main/java/one/microstream/integrations/spring/boot/types/config/MicrostreamConfigurationProperties.java
@@ -145,14 +145,6 @@ public class MicrostreamConfigurationProperties
     private String dataFileCleanupHeadFile;
 
     /**
-     * Allows you to force use for MicroStream Context Class Loader. Useful when Spring is supplemented with another class loader.
-     * Occasionally there is a problem, for example an attempt to use the hot replace feature for development, that the MicroStream is subsequently used from a different ClassLoader than the one that loaded the original objects.
-     * This causes subsequent problems and an exception: one.microstream.exceptions.TypeCastException
-     * Setting this value to true will force the standard class loader for MicroStream and Objects will be loaded by only one ClassLoader.
-     */
-    private Boolean useCurrentThreadClassLoader = false;
-
-    /**
      * Is the {@code StorageManager} started when the CDI bean for the instance is created or not.
      * Be aware that when you don't rely on the autostart of the StorageManager, you are responsible for starting it
      * and might result in Exceptions when code is executed that relies on a started StorageManager.
@@ -379,16 +371,6 @@ public class MicrostreamConfigurationProperties
     public void setDataFileCleanupHeadFile(String dataFileCleanupHeadFile)
     {
         this.dataFileCleanupHeadFile = dataFileCleanupHeadFile;
-    }
-
-    public Boolean getUseCurrentThreadClassLoader()
-    {
-        return useCurrentThreadClassLoader;
-    }
-
-    public void setUseCurrentThreadClassLoader(Boolean useCurrentThreadClassLoader)
-    {
-        this.useCurrentThreadClassLoader = useCurrentThreadClassLoader;
     }
 
     public Boolean getAutoStart()

--- a/integrations/spring-boot/src/main/java/one/microstream/integrations/spring/boot/types/config/StorageManagerProvider.java
+++ b/integrations/spring-boot/src/main/java/one/microstream/integrations/spring/boot/types/config/StorageManagerProvider.java
@@ -171,7 +171,7 @@ public class StorageManagerProvider
             return false;
         }
 
-        Optional<StorageClassData> storageClassData = this.storageMetaData.get()
+        Optional<StorageClassData<?>> storageClassData = this.storageMetaData.get()
                 .getStorageClassData()
                 .stream()
                 .filter(scd -> scd.getQualifier()

--- a/integrations/spring-boot/src/main/java/one/microstream/integrations/spring/boot/types/config/StorageManagerProvider.java
+++ b/integrations/spring-boot/src/main/java/one/microstream/integrations/spring/boot/types/config/StorageManagerProvider.java
@@ -33,6 +33,7 @@ import org.slf4j.Logger;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
+import org.springframework.context.ApplicationContext;
 import org.springframework.core.env.AbstractEnvironment;
 import org.springframework.core.env.EnumerablePropertySource;
 import org.springframework.core.env.Environment;
@@ -71,18 +72,20 @@ public class StorageManagerProvider
     // StorageManagerInitializer's
     private final Optional<StorageMetaData> storageMetaData;
     private final Environment env;
+    private final ApplicationContext applicationContext;
 
     public StorageManagerProvider(
             final List<EmbeddedStorageFoundationCustomizer> customizers,
             final List<StorageManagerInitializer> initializers,
             final Optional<StorageMetaData> storageMetaData,
-            final Environment env
-    )
+            final Environment env,
+            final ApplicationContext applicationContext)
     {
         this.customizers = customizers;
         this.initializers = initializers;
         this.storageMetaData = storageMetaData;
         this.env = env;
+        this.applicationContext = applicationContext;
     }
 
     private Map<String, String> readProperties(final String qualifier)
@@ -135,6 +138,8 @@ public class StorageManagerProvider
                     Thread.currentThread()
                             .getContextClassLoader())));
         }
+        embeddedStorageFoundation.onConnectionFoundation(
+                cf -> cf.setClassLoaderProvider(typeName -> applicationContext.getClassLoader()));
 
         ByQualifier.filter(this.customizers, qualifier)
                 .forEach(c -> c.customize(embeddedStorageFoundation));

--- a/integrations/spring-boot/src/main/java/one/microstream/integrations/spring/boot/types/config/StorageManagerProvider.java
+++ b/integrations/spring-boot/src/main/java/one/microstream/integrations/spring/boot/types/config/StorageManagerProvider.java
@@ -59,11 +59,11 @@ public class StorageManagerProvider
     public static final String PRIMARY_QUALIFIER = "Primary";
 
 
-    private final static Map<String, EmbeddedStorageManager> storageManagers = new ConcurrentHashMap<>();
+    private final Map<String, EmbeddedStorageManager> storageManagers = new ConcurrentHashMap<>();
 
     private static final String PREFIX = "one.microstream.";
 
-    private final static Logger logger = Logging.getLogger(StorageManagerFactory.class);
+    private final Logger logger = Logging.getLogger(StorageManagerFactory.class);
 
     private final List<EmbeddedStorageFoundationCustomizer> customizers;
     private final List<StorageManagerInitializer> initializers;

--- a/integrations/spring-boot/src/main/java/one/microstream/integrations/spring/boot/types/storage/StorageBeanFactory.java
+++ b/integrations/spring-boot/src/main/java/one/microstream/integrations/spring/boot/types/storage/StorageBeanFactory.java
@@ -143,8 +143,14 @@ public class StorageBeanFactory implements ApplicationContextAware, BeanDefiniti
             {
                 try
                 {
+                    // Try to get an appropriate ClassLoader from the Spring context
+                    ClassLoader classLoader = applicationContext.getClassLoader();
+                    // Fall back to the current ClassLoader if null
+                    if (classLoader == null)
+                        classLoader = this.getClass().getClassLoader();
+
                     // Don't use generics as that will not work with the Supplier that provides the Root object further in this method
-                    final Class clazz = Class.forName(beanDefinition.getBeanClassName());
+                    final Class clazz = classLoader.loadClass(beanDefinition.getBeanClassName());
                     final Storage storageAnnotation = (Storage) clazz.getAnnotation(Storage.class);
                     if (storageAnnotation != null)
                     {

--- a/integrations/spring-boot/src/main/java/one/microstream/integrations/spring/boot/types/storage/StorageBeanFactory.java
+++ b/integrations/spring-boot/src/main/java/one/microstream/integrations/spring/boot/types/storage/StorageBeanFactory.java
@@ -56,11 +56,13 @@ public class StorageBeanFactory implements ApplicationContextAware, BeanDefiniti
 
     private ApplicationContext applicationContext;
 
-    private final List<StorageClassData> storageClasses = new ArrayList<>();
+    private final List<StorageClassData<?>> storageClasses = new ArrayList<>();
 
-    public Object createRootObject(final String qualifier)
+    public <T> T createRootObject(final StorageClassData<T> storageClass)
     {
         LOGGER.debug("Creating Spring bean for @Storage annotated class");
+
+        final String qualifier = storageClass.getQualifier();
 
         final StorageManager storageManager;
         if (StorageManagerProvider.PRIMARY_QUALIFIER.equals(qualifier))
@@ -94,12 +96,12 @@ public class StorageBeanFactory implements ApplicationContextAware, BeanDefiniti
 
         this.processInitializers(storageManager, qualifier);
 
-        return root;
+        //noinspection unchecked
+        return (T) root;
     }
 
-    private Class findRootClass(final String qualifier)
+    private Class<?> findRootClass(final String qualifier)
     {
-
         return storageClasses.stream()
                 .filter(scd -> scd.getQualifier()
                         .equals(qualifier))
@@ -150,11 +152,11 @@ public class StorageBeanFactory implements ApplicationContextAware, BeanDefiniti
                         classLoader = this.getClass().getClassLoader();
 
                     // Don't use generics as that will not work with the Supplier that provides the Root object further in this method
-                    final Class clazz = classLoader.loadClass(beanDefinition.getBeanClassName());
-                    final Storage storageAnnotation = (Storage) clazz.getAnnotation(Storage.class);
+                    final Class<?> clazz = classLoader.loadClass(beanDefinition.getBeanClassName());
+                    final Storage storageAnnotation = clazz.getAnnotation(Storage.class);
                     if (storageAnnotation != null)
                     {
-                        this.storageClasses.add(new StorageClassData(clazz));
+                        this.storageClasses.add(new StorageClassData<>(clazz));
 
                         // Remove the original definition
                         beanDefinitionRegistry.removeBeanDefinition(definitionName);
@@ -167,16 +169,19 @@ public class StorageBeanFactory implements ApplicationContextAware, BeanDefiniti
             }
 
         }
-        final Map<String, List<Class>> storageClassByQualifier = storageClasses.stream()
-                .collect(Collectors.groupingBy(StorageClassData::getQualifier
-                        , Collectors.mapping(StorageClassData::getClazz, Collectors.toList())));
+        final Map<String, ? extends List<? extends Class<?>>> storageClassByQualifier = storageClasses.stream()
+                .collect(
+                        Collectors.groupingBy(StorageClassData::getQualifier,
+                                Collectors.mapping(StorageClassData::getClazz,
+                                        Collectors.toUnmodifiableList())
+                        )
+                );
 
-        final Map<String, List<Class>> multipleStorageClassByQualifier =
+        final Map<String, ? extends List<? extends Class<?>>> multipleStorageClassByQualifier =
                 storageClassByQualifier.entrySet()
                         .stream()
-                        .filter(entry -> entry.getValue()
-                                .size() > 1)
-                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                        .filter(entry -> entry.getValue().size() > 1)
+                        .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
 
         if (multipleStorageClassByQualifier.size() > 1)
         {
@@ -189,7 +194,7 @@ public class StorageBeanFactory implements ApplicationContextAware, BeanDefiniti
 
             // Add a definition for each class annotated with @Storage
             // Add a new definition based on the createRootObject 'factory method'
-            for (final StorageClassData storageClass : this.storageClasses)
+            for (final StorageClassData<?> storageClass : this.storageClasses)
             {
 
                 beanDefinitionRegistry
@@ -201,24 +206,24 @@ public class StorageBeanFactory implements ApplicationContextAware, BeanDefiniti
 
     }
 
-    private static String defineBeanName(StorageClassData storageClass)
+    private static String defineBeanName(StorageClassData<?> storageClass)
     {
 
         // Bean name must be the qualifier name!
         String result = storageClass.getQualifier();
         if (StorageManagerProvider.PRIMARY_QUALIFIER.equals(result))
         {
-            // Unless no Qualifier, than it must be the class name
+            // Unless no Qualifier, then it must be the class name
             result = storageClass.getClazz()
                     .getName();
         }
         return result;
     }
 
-    private BeanDefinition createBeanDefinition(final StorageClassData storageClass)
+    private <T> BeanDefinition createBeanDefinition(final StorageClassData<T> storageClass)
     {
         return BeanDefinitionBuilder.genericBeanDefinition(storageClass.getClazz(),
-                                                           () -> createRootObject(storageClass.getQualifier()))
+                                                           () -> createRootObject(storageClass))
                 //.addConstructorArgValue(storageClass.getQualifier())
                 .getBeanDefinition();
     }

--- a/integrations/spring-boot/src/main/java/one/microstream/integrations/spring/boot/types/storage/StorageBeanFactory.java
+++ b/integrations/spring-boot/src/main/java/one/microstream/integrations/spring/boot/types/storage/StorageBeanFactory.java
@@ -89,6 +89,10 @@ public class StorageBeanFactory implements ApplicationContextAware, BeanDefiniti
             storageManager.setRoot(root);
             storageManager.storeRoot();
         }
+        if (!root.getClass().equals(storageClass.getClazz()))
+        {
+            throw new IllegalStateException(String.format("Root class \"%s\" doesn't match bean class \"%s\"!", root.getClass(), storageClass.getClazz()));
+        }
 
         this.applicationContext
                 .getAutowireCapableBeanFactory()

--- a/integrations/spring-boot/src/main/java/one/microstream/integrations/spring/boot/types/storage/StorageClassData.java
+++ b/integrations/spring-boot/src/main/java/one/microstream/integrations/spring/boot/types/storage/StorageClassData.java
@@ -23,14 +23,14 @@ package one.microstream.integrations.spring.boot.types.storage;
 import one.microstream.integrations.spring.boot.types.config.StorageManagerProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 
-public class StorageClassData
+public class StorageClassData<T>
 {
 
-    private final Class<?> clazz;  // The Root class
+    private final Class<T> clazz;  // The Root class
 
     private final String qualifier;  // The qualifier
 
-    public StorageClassData(final Class<?> clazz)
+    public StorageClassData(final Class<T> clazz)
     {
         this.clazz = clazz;
         this.qualifier = findQualifier(clazz);
@@ -47,7 +47,7 @@ public class StorageClassData
         return StorageManagerProvider.PRIMARY_QUALIFIER;
     }
 
-    public Class getClazz()
+    public Class<T> getClazz()
     {
         return this.clazz;
     }
@@ -69,7 +69,7 @@ public class StorageClassData
             return false;
         }
 
-        StorageClassData that = (StorageClassData) o;
+        StorageClassData<?> that = (StorageClassData<?>) o;
 
         if (!this.clazz.equals(that.clazz))
         {

--- a/integrations/spring-boot/src/main/java/one/microstream/integrations/spring/boot/types/storage/StorageMetaData.java
+++ b/integrations/spring-boot/src/main/java/one/microstream/integrations/spring/boot/types/storage/StorageMetaData.java
@@ -28,14 +28,14 @@ import java.util.List;
  */
 public class StorageMetaData
 {
-    private final List<StorageClassData> storageClassData;
+    private final List<StorageClassData<?>> storageClassData;
 
-    public StorageMetaData(final List<StorageClassData> storageClassData)
+    public StorageMetaData(final List<StorageClassData<?>> storageClassData)
     {
         this.storageClassData = storageClassData;
     }
 
-    public List<StorageClassData> getStorageClassData()
+    public List<StorageClassData<?>> getStorageClassData()
     {
         return this.storageClassData;
     }

--- a/integrations/spring-boot3/README.md
+++ b/integrations/spring-boot3/README.md
@@ -22,14 +22,6 @@ the spring configuration will look like this:<br>
 This framework forwards all configuration keys to the MicroStream. It is important to follow the format that the
 MicroStream framework needs regardless of what the Spring configuration framework allows.
 
-### Class Loader
-
-Spring Boot class loader. If you use another class loader, such as hot replace, you may get an exception:
-`one.microstream.exceptions.TypeCastException`<br>
-In this case it is possible to force the use of the current thread's class loader for MicroStream.<br>
-`one.microstream.use-current-thread-class-loader=true` <br>
-This value is not passed to the MicroStream framework but is set directly in this module.
-
 ## Debug
 
 MicroStream Spring module supports standard Spring logging, so you can add into your config:<br>

--- a/integrations/spring-boot3/src/it/postgres-config/src/main/resources/application.properties
+++ b/integrations/spring-boot3/src/it/postgres-config/src/main/resources/application.properties
@@ -4,4 +4,3 @@ one.microstream.storage-filesystem.sql.postgres.data-source-provider=test.micros
 one.microstream.storage-filesystem.sql.postgres.password=password1
 one.microstream.storage-filesystem.sql.postgres.user=postgres
 one.microstream.storage-directory=microstream_storage
-one.microstream.use-current-thread-class-loader=false

--- a/integrations/spring-boot3/src/main/java/module-info.java
+++ b/integrations/spring-boot3/src/main/java/module-info.java
@@ -31,6 +31,7 @@ module microstream.integrations.spring.boot
 	exports one.microstream.integrations.spring.boot.types.oracle.nosql;
 	exports one.microstream.integrations.spring.boot.types.oraclecloud;
 	exports one.microstream.integrations.spring.boot.types.config;
+	exports one.microstream.integrations.spring.boot.types.storage;
 
 	requires transitive microstream.storage.embedded.configuration;
 	requires transitive spring.beans;

--- a/integrations/spring-boot3/src/main/java/one/microstream/integrations/spring/boot/types/MultipleStorageBeanException.java
+++ b/integrations/spring-boot3/src/main/java/one/microstream/integrations/spring/boot/types/MultipleStorageBeanException.java
@@ -28,13 +28,13 @@ import java.util.stream.Collectors;
 
 public class MultipleStorageBeanException extends BeansException
 {
-    public MultipleStorageBeanException(final Map<String, List<Class>> classes)
+    public MultipleStorageBeanException(final Map<String, ? extends List<? extends Class<?>>> classes)
     {
         super(String.format("Multiple beans are annotated with @Storage and the same qualifier: %s",
                             defineInfo(classes)));
     }
 
-    private static String defineInfo(final Map<String, List<Class>> classes)
+    private static String defineInfo(final Map<String, ? extends List<? extends Class<?>>> classes)
     {
         return classes.entrySet()
                 .stream()
@@ -42,7 +42,7 @@ public class MultipleStorageBeanException extends BeansException
                 .collect(Collectors.joining(" / "));
     }
 
-    private static String listClassNames(List<Class> classes)
+    private static String listClassNames(List<? extends Class<?>> classes)
     {
         return classes.stream()
                 .map(Class::getName)

--- a/integrations/spring-boot3/src/main/java/one/microstream/integrations/spring/boot/types/config/MicrostreamConfigurationProperties.java
+++ b/integrations/spring-boot3/src/main/java/one/microstream/integrations/spring/boot/types/config/MicrostreamConfigurationProperties.java
@@ -145,14 +145,6 @@ public class MicrostreamConfigurationProperties
     private String dataFileCleanupHeadFile;
 
     /**
-     * Allows you to force use for MicroStream Context Class Loader. Useful when Spring is supplemented with another class loader.
-     * Occasionally there is a problem, for example an attempt to use the hot replace feature for development, that the MicroStream is subsequently used from a different ClassLoader than the one that loaded the original objects.
-     * This causes subsequent problems and an exception: one.microstream.exceptions.TypeCastException
-     * Setting this value to true will force the standard class loader for MicroStream and Objects will be loaded by only one ClassLoader.
-     */
-    private Boolean useCurrentThreadClassLoader = false;
-
-    /**
      * Is the {@code StorageManager} started when the CDI bean for the instance is created or not.
      * Be aware that when you don't rely on the autostart of the StorageManager, you are responsible for starting it
      * and might result in Exceptions when code is executed that relies on a started StorageManager.
@@ -379,16 +371,6 @@ public class MicrostreamConfigurationProperties
     public void setDataFileCleanupHeadFile(String dataFileCleanupHeadFile)
     {
         this.dataFileCleanupHeadFile = dataFileCleanupHeadFile;
-    }
-
-    public Boolean getUseCurrentThreadClassLoader()
-    {
-        return useCurrentThreadClassLoader;
-    }
-
-    public void setUseCurrentThreadClassLoader(Boolean useCurrentThreadClassLoader)
-    {
-        this.useCurrentThreadClassLoader = useCurrentThreadClassLoader;
     }
 
     public Boolean getAutoStart()

--- a/integrations/spring-boot3/src/main/java/one/microstream/integrations/spring/boot/types/config/StorageManagerProvider.java
+++ b/integrations/spring-boot3/src/main/java/one/microstream/integrations/spring/boot/types/config/StorageManagerProvider.java
@@ -171,7 +171,7 @@ public class StorageManagerProvider
             return false;
         }
 
-        Optional<StorageClassData> storageClassData = this.storageMetaData.get()
+        Optional<StorageClassData<?>> storageClassData = this.storageMetaData.get()
                 .getStorageClassData()
                 .stream()
                 .filter(scd -> scd.getQualifier()

--- a/integrations/spring-boot3/src/main/java/one/microstream/integrations/spring/boot/types/config/StorageManagerProvider.java
+++ b/integrations/spring-boot3/src/main/java/one/microstream/integrations/spring/boot/types/config/StorageManagerProvider.java
@@ -33,6 +33,7 @@ import org.slf4j.Logger;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
+import org.springframework.context.ApplicationContext;
 import org.springframework.core.env.AbstractEnvironment;
 import org.springframework.core.env.EnumerablePropertySource;
 import org.springframework.core.env.Environment;
@@ -71,18 +72,20 @@ public class StorageManagerProvider
     // StorageManagerInitializer's
     private final Optional<StorageMetaData> storageMetaData;
     private final Environment env;
+    private final ApplicationContext applicationContext;
 
     public StorageManagerProvider(
             final List<EmbeddedStorageFoundationCustomizer> customizers,
             final List<StorageManagerInitializer> initializers,
             final Optional<StorageMetaData> storageMetaData,
-            final Environment env
-    )
+            final Environment env,
+            final ApplicationContext applicationContext)
     {
         this.customizers = customizers;
         this.initializers = initializers;
         this.storageMetaData = storageMetaData;
         this.env = env;
+        this.applicationContext = applicationContext;
     }
 
     private Map<String, String> readProperties(final String qualifier)
@@ -135,6 +138,8 @@ public class StorageManagerProvider
                     Thread.currentThread()
                             .getContextClassLoader())));
         }
+        embeddedStorageFoundation.onConnectionFoundation(
+                cf -> cf.setClassLoaderProvider(typeName -> applicationContext.getClassLoader()));
 
         ByQualifier.filter(this.customizers, qualifier)
                 .forEach(c -> c.customize(embeddedStorageFoundation));

--- a/integrations/spring-boot3/src/main/java/one/microstream/integrations/spring/boot/types/config/StorageManagerProvider.java
+++ b/integrations/spring-boot3/src/main/java/one/microstream/integrations/spring/boot/types/config/StorageManagerProvider.java
@@ -59,11 +59,11 @@ public class StorageManagerProvider
     public static final String PRIMARY_QUALIFIER = "Primary";
 
 
-    private final static Map<String, EmbeddedStorageManager> storageManagers = new ConcurrentHashMap<>();
+    private final Map<String, EmbeddedStorageManager> storageManagers = new ConcurrentHashMap<>();
 
     private static final String PREFIX = "one.microstream.";
 
-    private final static Logger logger = Logging.getLogger(StorageManagerFactory.class);
+    private final Logger logger = Logging.getLogger(StorageManagerFactory.class);
 
     private final List<EmbeddedStorageFoundationCustomizer> customizers;
     private final List<StorageManagerInitializer> initializers;

--- a/integrations/spring-boot3/src/main/java/one/microstream/integrations/spring/boot/types/storage/StorageBeanFactory.java
+++ b/integrations/spring-boot3/src/main/java/one/microstream/integrations/spring/boot/types/storage/StorageBeanFactory.java
@@ -56,11 +56,13 @@ public class StorageBeanFactory implements ApplicationContextAware, BeanDefiniti
 
     private ApplicationContext applicationContext;
 
-    private final List<StorageClassData> storageClasses = new ArrayList<>();
+    private final List<StorageClassData<?>> storageClasses = new ArrayList<>();
 
-    public Object createRootObject(final String qualifier)
+    public <T> T createRootObject(final StorageClassData<T> storageClass)
     {
         LOGGER.debug("Creating Spring bean for @Storage annotated class");
+
+        final String qualifier = storageClass.getQualifier();
 
         final StorageManager storageManager;
         if (StorageManagerProvider.PRIMARY_QUALIFIER.equals(qualifier))
@@ -94,12 +96,12 @@ public class StorageBeanFactory implements ApplicationContextAware, BeanDefiniti
 
         this.processInitializers(storageManager, qualifier);
 
-        return root;
+        //noinspection unchecked
+        return (T) root;
     }
 
-    private Class findRootClass(final String qualifier)
+    private Class<?> findRootClass(final String qualifier)
     {
-
         return storageClasses.stream()
                 .filter(scd -> scd.getQualifier()
                         .equals(qualifier))
@@ -150,11 +152,11 @@ public class StorageBeanFactory implements ApplicationContextAware, BeanDefiniti
                         classLoader = this.getClass().getClassLoader();
 
                     // Don't use generics as that will not work with the Supplier that provides the Root object further in this method
-                    final Class clazz = classLoader.loadClass(beanDefinition.getBeanClassName());
-                    final Storage storageAnnotation = (Storage) clazz.getAnnotation(Storage.class);
+                    final Class<?> clazz = classLoader.loadClass(beanDefinition.getBeanClassName());
+                    final Storage storageAnnotation = clazz.getAnnotation(Storage.class);
                     if (storageAnnotation != null)
                     {
-                        this.storageClasses.add(new StorageClassData(clazz));
+                        this.storageClasses.add(new StorageClassData<>(clazz));
 
                         // Remove the original definition
                         beanDefinitionRegistry.removeBeanDefinition(definitionName);
@@ -167,16 +169,19 @@ public class StorageBeanFactory implements ApplicationContextAware, BeanDefiniti
             }
 
         }
-        final Map<String, List<Class>> storageClassByQualifier = storageClasses.stream()
-                .collect(Collectors.groupingBy(StorageClassData::getQualifier
-                        , Collectors.mapping(StorageClassData::getClazz, Collectors.toList())));
+        final Map<String, ? extends List<? extends Class<?>>> storageClassByQualifier = storageClasses.stream()
+                .collect(
+                        Collectors.groupingBy(StorageClassData::getQualifier,
+                                Collectors.mapping(StorageClassData::getClazz,
+                                        Collectors.toUnmodifiableList())
+                        )
+                );
 
-        final Map<String, List<Class>> multipleStorageClassByQualifier =
+        final Map<String, ? extends List<? extends Class<?>>> multipleStorageClassByQualifier =
                 storageClassByQualifier.entrySet()
                         .stream()
-                        .filter(entry -> entry.getValue()
-                                .size() > 1)
-                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                        .filter(entry -> entry.getValue().size() > 1)
+                        .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
 
         if (multipleStorageClassByQualifier.size() > 1)
         {
@@ -189,7 +194,7 @@ public class StorageBeanFactory implements ApplicationContextAware, BeanDefiniti
 
             // Add a definition for each class annotated with @Storage
             // Add a new definition based on the createRootObject 'factory method'
-            for (final StorageClassData storageClass : this.storageClasses)
+            for (final StorageClassData<?> storageClass : this.storageClasses)
             {
 
                 beanDefinitionRegistry
@@ -201,24 +206,24 @@ public class StorageBeanFactory implements ApplicationContextAware, BeanDefiniti
 
     }
 
-    private static String defineBeanName(StorageClassData storageClass)
+    private static String defineBeanName(StorageClassData<?> storageClass)
     {
 
         // Bean name must be the qualifier name!
         String result = storageClass.getQualifier();
         if (StorageManagerProvider.PRIMARY_QUALIFIER.equals(result))
         {
-            // Unless no Qualifier, than it must be the class name
+            // Unless no Qualifier, then it must be the class name
             result = storageClass.getClazz()
                     .getName();
         }
         return result;
     }
 
-    private BeanDefinition createBeanDefinition(final StorageClassData storageClass)
+    private <T> BeanDefinition createBeanDefinition(final StorageClassData<T> storageClass)
     {
         return BeanDefinitionBuilder.genericBeanDefinition(storageClass.getClazz(),
-                                                           () -> createRootObject(storageClass.getQualifier()))
+                                                           () -> createRootObject(storageClass))
                 //.addConstructorArgValue(storageClass.getQualifier())
                 .getBeanDefinition();
     }

--- a/integrations/spring-boot3/src/main/java/one/microstream/integrations/spring/boot/types/storage/StorageBeanFactory.java
+++ b/integrations/spring-boot3/src/main/java/one/microstream/integrations/spring/boot/types/storage/StorageBeanFactory.java
@@ -89,6 +89,10 @@ public class StorageBeanFactory implements ApplicationContextAware, BeanDefiniti
             storageManager.setRoot(root);
             storageManager.storeRoot();
         }
+        if (!root.getClass().equals(storageClass.getClazz()))
+        {
+            throw new IllegalStateException(String.format("Root class \"%s\" doesn't match bean class \"%s\"!", root.getClass(), storageClass.getClazz()));
+        }
 
         this.applicationContext
                 .getAutowireCapableBeanFactory()

--- a/integrations/spring-boot3/src/main/java/one/microstream/integrations/spring/boot/types/storage/StorageBeanFactory.java
+++ b/integrations/spring-boot3/src/main/java/one/microstream/integrations/spring/boot/types/storage/StorageBeanFactory.java
@@ -9,13 +9,13 @@ package one.microstream.integrations.spring.boot.types.storage;
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
- * 
+ *
  * This Source Code may also be made available under the following Secondary
  * Licenses when the conditions for such availability set forth in the Eclipse
  * Public License, v. 2.0 are satisfied: GNU General Public License, version 2
  * with the GNU Classpath Exception which is
  * available at https://www.gnu.org/software/classpath/license.html.
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  * #L%
  */
@@ -143,8 +143,14 @@ public class StorageBeanFactory implements ApplicationContextAware, BeanDefiniti
             {
                 try
                 {
+                    // Try to get an appropriate ClassLoader from the Spring context
+                    ClassLoader classLoader = applicationContext.getClassLoader();
+                    // Fall back to the current ClassLoader if null
+                    if (classLoader == null)
+                        classLoader = this.getClass().getClassLoader();
+
                     // Don't use generics as that will not work with the Supplier that provides the Root object further in this method
-                    final Class clazz = Class.forName(beanDefinition.getBeanClassName());
+                    final Class clazz = classLoader.loadClass(beanDefinition.getBeanClassName());
                     final Storage storageAnnotation = (Storage) clazz.getAnnotation(Storage.class);
                     if (storageAnnotation != null)
                     {

--- a/integrations/spring-boot3/src/main/java/one/microstream/integrations/spring/boot/types/storage/StorageClassData.java
+++ b/integrations/spring-boot3/src/main/java/one/microstream/integrations/spring/boot/types/storage/StorageClassData.java
@@ -23,14 +23,14 @@ package one.microstream.integrations.spring.boot.types.storage;
 import one.microstream.integrations.spring.boot.types.config.StorageManagerProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 
-public class StorageClassData
+public class StorageClassData<T>
 {
 
-    private final Class<?> clazz;  // The Root class
+    private final Class<T> clazz;  // The Root class
 
     private final String qualifier;  // The qualifier
 
-    public StorageClassData(final Class<?> clazz)
+    public StorageClassData(final Class<T> clazz)
     {
         this.clazz = clazz;
         this.qualifier = findQualifier(clazz);
@@ -47,7 +47,7 @@ public class StorageClassData
         return StorageManagerProvider.PRIMARY_QUALIFIER;
     }
 
-    public Class getClazz()
+    public Class<T> getClazz()
     {
         return this.clazz;
     }
@@ -69,7 +69,7 @@ public class StorageClassData
             return false;
         }
 
-        StorageClassData that = (StorageClassData) o;
+        StorageClassData<?> that = (StorageClassData<?>) o;
 
         if (!this.clazz.equals(that.clazz))
         {

--- a/integrations/spring-boot3/src/main/java/one/microstream/integrations/spring/boot/types/storage/StorageMetaData.java
+++ b/integrations/spring-boot3/src/main/java/one/microstream/integrations/spring/boot/types/storage/StorageMetaData.java
@@ -28,14 +28,14 @@ import java.util.List;
  */
 public class StorageMetaData
 {
-    private final List<StorageClassData> storageClassData;
+    private final List<StorageClassData<?>> storageClassData;
 
-    public StorageMetaData(final List<StorageClassData> storageClassData)
+    public StorageMetaData(final List<StorageClassData<?>> storageClassData)
     {
         this.storageClassData = storageClassData;
     }
 
-    public List<StorageClassData> getStorageClassData()
+    public List<StorageClassData<?>> getStorageClassData()
     {
         return this.storageClassData;
     }


### PR DESCRIPTION
Closes #517

I wasn't able to add failing integration tests because Spring Boot DevTools checks if it's running in a test environment or in GraalVM multiple times, and deactivates itself.