### PR TITLE
Fixes issue #584

### DIFF
--- a/base/src/main/java/one/microstream/collections/lazy/LazySegmentUnloader.java
+++ b/base/src/main/java/one/microstream/collections/lazy/LazySegmentUnloader.java
@@ -210,7 +210,10 @@ public interface LazySegmentUnloader
 		@Override
 		public void remove(final LazySegment<?> segment)
 		{
-			this.loadedSegments.remove(segment);
+			if(this.loadedSegments != null)
+			{
+				this.loadedSegments.remove(segment);
+			}
 		}
 		
 	}
@@ -313,7 +316,10 @@ public interface LazySegmentUnloader
 		@Override
 		public void remove(final LazySegment<?> segment)
 		{
-			this.loadedSegments.remove(segment);
+			if(this.loadedSegments != null)
+			{
+				this.loadedSegments.remove(segment);
+			}
 		}
 				
 	}


### PR DESCRIPTION
Fixed a nullpointer exception in one.microstream.collections.lazy.LazySegmentUnloader.remove in case of no loaded segments.