### PR TITLE
Added the dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+    - package-ecosystem: "maven"
+      directory: "/"
+      schedule:
+          interval: "daily"
+          time: "02:00"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,12 @@
 version: 2
 updates:
-    - package-ecosystem: "maven"
-      directory: "/"
-      schedule:
-          interval: "daily"
-          time: "02:00"
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+    allow:
+      - dependency-name: "com.gradle:gradle-enterprise-maven-extension"
+        dependency-type: "direct:production"
+      - dependency-name: "com.gradle:common-custom-user-data-maven-extension"
+        dependency-type: "direct:production"


### PR DESCRIPTION
Added the dependabot configuration. 

Dependabot takes the effort out of maintaining your dependencies. You can use it to ensure that your repository automatically keeps up with the latest releases of the packages and applications it depends on.

[Learn more about Dependabot](https://help.github.com/en/github/administering-a-repository/about-github-dependabot)