### PR TITLE
Zj/fix build also for javac 0923

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -40,6 +40,7 @@
 						<id>default-compile</id>
 						<configuration>
 							<compilerArgument>-proc:none</compilerArgument>
+							<compilerArgument>-warn:-serial,-unusedImport</compilerArgument>
 						</configuration>
 					</execution>
 				</executions>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -40,7 +40,6 @@
 						<id>default-compile</id>
 						<configuration>
 							<compilerArgument>-proc:none</compilerArgument>
-							<compilerArgument>-warn:-serial,-unusedImport</compilerArgument>
 						</configuration>
 					</execution>
 				</executions>
@@ -59,5 +58,33 @@
 			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>eclipse</id>
+			<activation>
+				<property>
+					<name>maven.compiler.compilerId</name>
+					<value>eclipse</value>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-compiler-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>default-compile</id>
+								<configuration>
+									<compilerArgument>-warn:-serial,-unusedImport</compilerArgument>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 		<maven.compiler.compilerId>javac</maven.compiler.compilerId>
 		<maven.version.minimum>3.8.1</maven.version.minimum>
 		<maven.java.version.minimum>11</maven.java.version.minimum>
-		<org.eclipse.jdt.ecj.version>3.34.0</org.eclipse.jdt.ecj.version>
+		<org.eclipse.jdt.ecj.version>3.29.0</org.eclipse.jdt.ecj.version>
 		<license.inceptionYear>2019</license.inceptionYear>
 		<license.licenseName>epl_v2</license.licenseName>
 		<license.licenceFile>${basedir}/LICENSE</license.licenceFile>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 		<maven.compiler.compilerId>javac</maven.compiler.compilerId>
 		<maven.version.minimum>3.8.1</maven.version.minimum>
 		<maven.java.version.minimum>11</maven.java.version.minimum>
-		<org.eclipse.jdt.ecj.version>3.29.0</org.eclipse.jdt.ecj.version>
+		<org.eclipse.jdt.ecj.version>3.34.0</org.eclipse.jdt.ecj.version>
 		<license.inceptionYear>2019</license.inceptionYear>
 		<license.licenseName>epl_v2</license.licenseName>
 		<license.licenceFile>${basedir}/LICENSE</license.licenceFile>


### PR DESCRIPTION
The previous PR deactivated some warnings for the eclipse compiler. Unfortunately this has the effect that the Javac compiler is not compatible with this setting and exits with an error. So I have added a special setting for the eclipse profiler to the profile, which is activated automatically if the eclipse compiler is selected. 