### PR TITLE
fix profile

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -65,7 +65,7 @@
 			<activation>
 				<property>
 					<name>maven.compiler.compilerId</name>
-					<value>eclipse</value>
+					<value>!javac</value>
 				</property>
 			</activation>
 			<build>


### PR DESCRIPTION
It must be so. The default compiler for this module is eclipse. It can be replace as parameter from outside. At this time, is the parameter also enviroment properties and only this time is visible for maven. 