### PR TITLE
Migrated from gradleEnterprise to Develocity 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: "daily"
       time: "02:00"
     allow:
-      - dependency-name: "com.gradle:gradle-enterprise-maven-extension"
+      - dependency-name: "com.gradle:develocity-maven-extension"
         dependency-type: "production"
       - dependency-name: "com.gradle:common-custom-user-data-maven-extension"
         dependency-type: "production"

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ dependency-reduced-pom.xml
 release.properties
 buildNumber.properties
 .flattened-pom.xml
-.mvn/.gradle-enterprise
+.mvn/.develocity
 
 # Gradle
 .gradle/

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -1,19 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 
-<gradleEnterprise
-        xmlns="https://www.gradle.com/gradle-enterprise-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://www.gradle.com/gradle-enterprise-maven https://www.gradle.com/schema/gradle-enterprise-maven.xsd">
+<develocity
+  xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://www.gradle.com/develocity-maven https://www.gradle.com/schema/develocity-maven.xsd">
     <server>
         <url>https://ge.microstream.one</url>
         <allowUntrusted>false</allowUntrusted>
     </server>
     <buildScan>
-        <capture>
-            <goalInputFiles>true</goalInputFiles>
-        </capture>
         <backgroundBuildScanUpload>#{isFalse(env['CI'])}</backgroundBuildScanUpload>
-        <publish>ALWAYS</publish>
-        <publishIfAuthenticated>true</publishIfAuthenticated>
+        <publishing>
+            <onlyIf><![CDATA[authenticated]]></onlyIf>
+        </publishing>
         <obfuscation>
             <ipAddresses>#{{'0.0.0.0'}}</ipAddresses>
         </obfuscation>
@@ -27,4 +25,4 @@
             <storeEnabled>#{isTrue(env['CI'])}</storeEnabled>
         </remote>
     </buildCache>
-</gradleEnterprise>
+</develocity>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,12 +2,12 @@
 <extensions>
     <extension>
         <groupId>com.gradle</groupId>
-        <artifactId>gradle-enterprise-maven-extension</artifactId>
-        <version>1.20.1</version>
+        <artifactId>develocity-maven-extension</artifactId>
+        <version>1.21.4</version>
     </extension>
     <extension>
         <groupId>com.gradle</groupId>
         <artifactId>common-custom-user-data-maven-extension</artifactId>
-        <version>1.13</version>
+        <version>2.0</version>
     </extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -371,10 +371,10 @@
 				</plugin>
 				<plugin>
 					<groupId>com.gradle</groupId>
-					<artifactId>gradle-enterprise-maven-extension</artifactId>
-					<version>1.20.1</version>
+					<artifactId>develocity-maven-extension</artifactId>
+					<version>1.21.4</version>
 					<configuration>
-						<gradleEnterprise>
+						<develocity>
 							<normalization>
 								<runtimeClassPath>
 									<metaInf>
@@ -399,7 +399,7 @@
 									</propertiesNormalizations>
 								</runtimeClassPath>
 							</normalization>
-						</gradleEnterprise>
+						</develocity>
 					</configuration>
 				</plugin>
 			</plugins>


### PR DESCRIPTION
Migrated from gradleEnterprise 1.20.1 to Develocity extension 1.21.4 and updated Common Custom User Data Gradle plugin to 2.0. Starting with version 1.21 the plugin is available under the “Develocity” brand. Some configuration APIs have been renamed or deprecated; functionally, there should be no changes.